### PR TITLE
Improve searching for EroMuse sources with support for nested albums

### DIFF
--- a/src/all/eromuse/build.gradle
+++ b/src/all/eromuse/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'EroMuse (8muses and Erofus)'
     pkgNameSuffix = 'all.eromuse'
     extClass = '.EroMuseFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
# ====== WARNING: NSFW LINKS ======

> **TLDR**: (#5241) I was trying to add [this](https://comics.8muses.com/comics/album/Fakku-Comics/E-musu-Aki/Parallel-World-ErosSwine-Finale) to my library but was not able to since it was being parsed as a chapter of its [parent](https://comics.8muses.com/comics/album/Fakku-Comics/E-musu-Aki/). Seemed odd to me since the parent folder was acting more like an artist-filter instead of a manga by itself. This PR improves searching and other shit in the EroMuse extension.

### Context

The problems are described with examples here: #5237, #5238, #5241.

`VARIOUS_AUTHORS`: An album that holds `AUTHOR` albums, usually grouped by organization or source-specific collection scheme eg. [fakku](https://comics.8muses.com/comics/album/fakku-comics)
`ARTIST:` An album that holds `MANGA` albums made by an artist, usually a direct child of a `VARIOUS_AUTHORS` - eg. [bosshi](https://comics.8muses.com/comics/album/Fakku-Comics/Bosshi)
`MANGA`: An album that holds actual images eg. [after summer after](https://comics.8muses.com/comics/album/Fakku-Comics/Bosshi/After-Summer-After)
`SEARCH_RESULTS_OR_BASE`: An album that is returned from a search result or the latest front page, which could potentially include ALL kinds of albums

Note that some `MANGA` albums can be nested at depth of n. Direct descendants of `MANGA` albums often best fit the notion of chapters eg. [alfie](https://comics.8muses.com/comics/album/Incase-Comics/Comic/Alfie). Other n-level nested albums also just use an arbitrary system of nesting eg. [area69 no.1](https://comics.8muses.com/comics/album/Various-Authors/Firollian/Area69/Area69-no_1) but can also be treated as chapters.

### Problem

The n-level nesting of `MANGA` albums present a challenge since the app can only display 2-level of hierarchy using manga > chapters.

In addition, there exists only a small number yet very large `VARIOUS_AUTHORS` such as [this](https://comics.8muses.com/comics/album/various-authors), [this](https://comics.8muses.com/comics/album/hentai-and-manga-english) or [this](https://comics.8muses.com/comics/album/fakku-comics). Leaving them out or simply parsing them as chapters (for albums at depth of 2) could omit huge amount of unreachable content. 

### Solution

One way is to distinguish the item URLs by its segments and modifying the parse logic accordingly. For example:
1. `comics/album/Fakku-Comics` should be counted as a `VARIOUS_AUTHORS` album since the fakku album uses this system and it only contains `AUTHOR` albums. When parsing, `VARIOUS_AUTHORS` albums should be placed back to the stack and expanded (twice) until we see actual `MANGA` albums.
2. `/comics/album/Fakku-Comics/Bosshi` should be counted as an `AUTHOR` album since it's a _1-level_ descendant of a `VARIOUS_AUTHORS` album.  When parsing, `AUTHOR` albums should be placed back to the stack and expanded (once) until we see actual `MANGA` albums. 
3. `/comics/album/Fakku-Comics/Bosshi/After-Summer-After` should be counted as a `MANGA` album since it's a _n-level_ descendant of a `VARIOUS_AUTHORS` album where _n > 1_. Parsing of `MANGA` albums are described below.
4. `/comics/album/Incase-Comics/Comic` should be counted as a `MANGA` album despite having no images of its own since it's a 1-level descendant of an `AUTHOR` album. Parsing of `MANGA` albums are described below.
5. `/comics/album/Incase-Comics/Comic/Alfie` and `/comics/album/Incase-Comics/Comic/Alfie/Chapter-1-3` which are descendants of *4* (a `MANGA` album) should also be counted as `MANGA` since they are still _n-level_ descendants of an `AUTHOR` album where _n > 1_. Parsing of `MANGA` albums are described below.
6. `comics/album/ShadBase-Comics` should be counted as an `AUTHOR` album since it directly holds works (`MANGA` albums) done by an author, although not a descendant of a `VARIOUS_AUTHORS` album. When parsing, `AUTHOR` albums should be dealt with as described in *2*.
7. `comics/album/ShadBase-Comics/RickMorty` and all nested descendants of this should be counted as `MANGA` albums since they're all under the same `AUTHOR` album, same as how *5* works but for a different parent. Parsing of `MANGA` albums are described below.

When parsing `MANGA` albums:
1. If the album only contains images and no nested albums, they should be given a default chapter with all images parked inside.
2. If the album contains images and nested albums, child `MANGA` albums at depth of _n > 2_ should be flattened at the level of its parent at _n = 2_ (to be rendered as chapters) using recursive GET requests, with the images appearing first followed by nested images (follows DFS-like algorithm). The images of the album are to be placed at a default chapter as described in the previous case.
3. If the album contains only nested albums, the child `MANGA` albums are to be flattened (as per previous case) and registered as chapters of their own.

Closes #5237
Closes #5238
Closes #5241