### PR TITLE
Add Spanish and Spanish Translation to Webtoons

### DIFF
--- a/src/all/webtoons/build.gradle
+++ b/src/all/webtoons/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Webtoons'
     pkgNameSuffix = 'all.webtoons'
     extClass = '.WebtoonsFactory'
-    extVersionCode = 22
+    extVersionCode = 23
     libVersion = '1.2'
 }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
@@ -77,5 +77,4 @@ class WebtoonsChineseTraditional : WebtoonsDefault("zh", "zh-hant", "zh_TW", Sim
 
 class WebtoonsFr : WebtoonsDefault("fr", dateFormat = SimpleDateFormat("d MMM yyyy", Locale.FRENCH))
 
-
 class WebtoonsEs : WebtoonsDefault("es", dateFormat = SimpleDateFormat("d MMM yyyy", Locale("es")))

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
@@ -13,6 +13,7 @@ class WebtoonsFactory : SourceFactory {
         WebtoonsIndonesian(),
         WebtoonsThai(),
         WebtoonsFr(),
+        WebtoonsEs(),
         DongmanManhua(),
 
         // Fan translations
@@ -46,7 +47,8 @@ class WebtoonsFactory : SourceFactory {
         WebtoonsTranslate("sv", "SWE"),
         WebtoonsTranslate("bn", "BEN"),
         WebtoonsTranslate("fa", "PER"),
-        WebtoonsTranslate("uk", "UKR")
+        WebtoonsTranslate("uk", "UKR"),
+        WebtoonsTranslate("es", "SPA")
     )
 }
 
@@ -74,3 +76,6 @@ class WebtoonsThai : WebtoonsDefault("th", dateFormat = SimpleDateFormat("d MMM 
 class WebtoonsChineseTraditional : WebtoonsDefault("zh", "zh-hant", "zh_TW", SimpleDateFormat("yyyy/MM/dd", Locale.TRADITIONAL_CHINESE))
 
 class WebtoonsFr : WebtoonsDefault("fr", dateFormat = SimpleDateFormat("d MMM yyyy", Locale.FRENCH))
+
+
+class WebtoonsEs : WebtoonsDefault("es", dateFormat = SimpleDateFormat("d MMM yyyy", Locale("es")))


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to update the `extVersionCode` value in their `build.gradle` files as well.

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
Adds Spanish and Spanish Translation to Webtoons extension.

Closes #5396