### PR TITLE
Various Doujins ext fixes

### DIFF
--- a/src/en/doujins/build.gradle
+++ b/src/en/doujins/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Doujins'
     pkgNameSuffix = 'en.doujins'
     extClass = '.Doujins'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
+++ b/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
@@ -103,8 +103,9 @@ class Doujins : HttpSource() {
         val document = response.asJsoup()
         return SManga.create().apply {
             title = document.select(".folder-title a").last().text()
-            artist = document.select(".gallery-artist a").joinToString(", ") { it.text() }
+            artist = document.select(".gallery-artist a").joinToString { it.text() }
             author = artist
+            genre = document.select(".tag-area").first().select("a").joinToString { it.text() }
         }
     }
 

--- a/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
+++ b/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
@@ -50,7 +50,9 @@ class Doujins : HttpSource() {
                 name = "Chapter"
                 setUrlWithoutDomain(response.request().url().toString())
 
-                val date = response.asJsoup().select(".folder-message").last().text().substringBefore(" • ")
+                val dateAndPageCountString = response.asJsoup().select(".text-md-right.text-sm-left > .folder-message").text()
+
+                val date = dateAndPageCountString.substringBefore(" • ")
                 for (dateFormat in MANGA_DETAILS_DATE_FORMAT) {
                     if (date_upload == 0L)
                         date_upload = dateFormat.parseOrNull(date)?.time ?: 0L

--- a/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
+++ b/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 @Nsfw
 class Doujins : HttpSource() {
@@ -82,7 +83,7 @@ class Doujins : HttpSource() {
     }
 
     private fun getLatestPageUrl(page: Int): String {
-        val endDate = Calendar.getInstance().apply {
+        val endDate = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
             add(Calendar.DATE, 1)
             set(Calendar.HOUR_OF_DAY, 0)
             set(Calendar.MINUTE, 0)


### PR DESCRIPTION
Fixes:
1. Chapter upload date not parsed for certain mangas that have requester details due to incorrect selector
2. Fetching latest page incorrectly uses local timezone instead of UTC
3. Tags not parsed for mangas from search or popular page
