### PR TITLE
Add support for collections and refactor manga description for Pururin ext

### DIFF
--- a/src/en/pururin/build.gradle
+++ b/src/en/pururin/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Pururin'
     pkgNameSuffix = 'en.pururin'
     extClass = '.Pururin'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
1. Add support for collections i.e. multi-series mangas
2. Removes redundant information from description: title and tags
3. Adds other information to description: circle, category, character and language
4. Adds scanlator to manga attributes if available