### PR TITLE
LANraragi: Filters, Latest, misc API.

### DIFF
--- a/src/all/lanraragi/build.gradle
+++ b/src/all/lanraragi/build.gradle
@@ -5,8 +5,13 @@ ext {
     extName = 'LANraragi'
     pkgNameSuffix = 'all.lanraragi'
     extClass = '.LANraragi'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
+}
+
+dependencies {
+    implementation 'io.reactivex:rxandroid:1.2.1'
+    implementation 'io.reactivex:rxjava:1.3.6'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -261,7 +261,6 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         val latestNewOnlyPref = CheckBoxPreference(screen.context).apply {
             key = "latestNewOnly"
             title = "Latest - New Only"
-            summary = ""
             setDefaultValue(true)
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -283,7 +282,6 @@ open class LANraragi : ConfigurableSource, HttpSource() {
 
                 this.apply {
                     text = latestNamespacePref
-                    summary = "Sort by the given namespace for Latest, such as date_added."
                 }
 
                 preferences.edit().putString("latestNamespacePref", newValue).commit()
@@ -341,7 +339,6 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         val latestNewOnlyPref = androidx.preference.CheckBoxPreference(screen.context).apply {
             key = "latestNewOnly"
             title = "Latest - New Only"
-            summary = ""
             setDefaultValue(true)
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -363,7 +360,6 @@ open class LANraragi : ConfigurableSource, HttpSource() {
 
                 this.apply {
                     text = latestNamespacePref
-                    summary = "Sort by the given namespace for Latest, such as date_added."
                 }
 
                 preferences.edit().putString("latestNamespacePref", newValue).commit()

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -49,7 +49,7 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         get() = preferences.getString("apiKey", "")!!
 
     private val latestNamespacePref: String
-        get() = preferences.getString("latestNamespacePref", "")!!
+        get() = preferences.getString("latestNamespacePref", DEFAULT_SORT_BY_NS)!!
 
     private val gson: Gson = Gson()
 
@@ -120,7 +120,7 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         if (prefNewOnly) filters.add(NewArchivesOnly(true))
 
         if (latestNamespacePref.isNotBlank()) {
-            filters.add(SortByNamespace("date_added"))
+            filters.add(SortByNamespace(latestNamespacePref))
             filters.add(DescendingOrder(true))
         }
 
@@ -261,7 +261,8 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         val latestNewOnlyPref = CheckBoxPreference(screen.context).apply {
             key = "latestNewOnly"
             title = "Latest - New Only"
-            summary = "Only show items marked \"new\" for Latest."
+            summary = ""
+            setDefaultValue(true)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val checkValue = newValue as Boolean
@@ -273,15 +274,16 @@ open class LANraragi : ConfigurableSource, HttpSource() {
             key = "latestNamespacePref"
             title = "Latest - Sort by Namespace"
             text = latestNamespacePref
-            summary = "If specified, sort by this namespace for Latest. For example date_added.\nCurrent: $latestNamespacePref"
+            summary = "Sort by the given namespace for Latest, such as date_added."
             dialogTitle = "Latest - Sort by Namespace"
+            setDefaultValue(DEFAULT_SORT_BY_NS)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val latestNamespacePref = newValue as String
 
                 this.apply {
                     text = latestNamespacePref
-                    summary = "If specified, sort by this namespace for Latest. For example date_added.\nCurrent: $latestNamespacePref"
+                    summary = "Sort by the given namespace for Latest, such as date_added."
                 }
 
                 preferences.edit().putString("latestNamespacePref", newValue).commit()
@@ -339,7 +341,8 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         val latestNewOnlyPref = androidx.preference.CheckBoxPreference(screen.context).apply {
             key = "latestNewOnly"
             title = "Latest - New Only"
-            summary = "Only show items marked \"new\" for Latest."
+            summary = ""
+            setDefaultValue(true)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val checkValue = newValue as Boolean
@@ -351,15 +354,16 @@ open class LANraragi : ConfigurableSource, HttpSource() {
             key = "latestNamespacePref"
             title = "Latest - Sort by Namespace"
             text = latestNamespacePref
-            summary = "If specified, sort by this namespace for Latest. For example date_added.\nCurrent: $latestNamespacePref"
+            summary = "Sort by the given namespace for Latest, such as date_added."
             dialogTitle = "Latest - Sort by Namespace"
+            setDefaultValue(DEFAULT_SORT_BY_NS)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val latestNamespacePref = newValue as String
 
                 this.apply {
                     text = latestNamespacePref
-                    summary = "If specified, sort by this namespace for Latest. For example date_added.\nCurrent: $latestNamespacePref"
+                    summary = "Sort by the given namespace for Latest, such as date_added."
                 }
 
                 preferences.edit().putString("latestNamespacePref", newValue).commit()
@@ -464,5 +468,9 @@ open class LANraragi : ConfigurableSource, HttpSource() {
                 },
                 {}
             )
+    }
+
+    companion object {
+        private const val DEFAULT_SORT_BY_NS = "date_added"
     }
 }

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -136,7 +136,11 @@ open class LANraragi : ConfigurableSource, HttpSource() {
                 is UntaggedArchivesOnly -> if (filter.state) uri.appendQueryParameter("untaggedonly", "true")
                 is DescendingOrder -> if (filter.state) uri.appendQueryParameter("order", "desc")
                 is SortByNamespace -> if (filter.state.isNotEmpty()) uri.appendQueryParameter("sortby", filter.state.trim())
-                is CategoryGroup -> uri.appendQueryParameter("category", filter.state.first { it.state }.id)
+                is CategoryGroup -> {
+                    val category = filter.state.firstOrNull { it.state }
+
+                    if (category != null) uri.appendQueryParameter("category", category.id)
+                }
             }
         }
 

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -195,7 +195,7 @@ open class LANraragi : ConfigurableSource, HttpSource() {
     private class DescendingOrder(overrideState: Boolean = false) : Filter.CheckBox("Descending Order", overrideState)
     private class NewArchivesOnly(overrideState: Boolean = false) : Filter.CheckBox("New Archives Only", overrideState)
     private class UntaggedArchivesOnly : Filter.CheckBox("Untagged Archives Only", false)
-    private class StartingPage(lastResultCount: String) : Filter.Text("Starting Page (per: $lastResultCount)", "")
+    private class StartingPage() : Filter.Text("Starting Page", "")
     private class SortByNamespace(defaultText: String = "") : Filter.Text("Sort by (namespace)", defaultText)
     private class CategorySelect(categories: Array<Pair<String?, String>>) : UriPartFilter("Category", categories)
 
@@ -205,7 +205,7 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         DescendingOrder(),
         NewArchivesOnly(),
         UntaggedArchivesOnly(),
-        StartingPage(lastResultCount.toString()),
+        StartingPage(),
         SortByNamespace()
     )
 

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -83,9 +83,9 @@ open class LANraragi : ConfigurableSource, HttpSource() {
                 chapter_number = 1F
                 name = "Chapter"
 
-                val date = getDateAdded(archive.tags).toLongOrNull()
-                if (date != null)
-                    date_upload = date
+                getDateAdded(archive.tags).toLongOrNull()?.let {
+                    date_upload = it
+                }
             }
         )
     }

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -119,7 +119,7 @@ open class LANraragi : ConfigurableSource, HttpSource() {
 
         if (prefNewOnly) filters.add(NewArchivesOnly(true))
 
-        if (latestNamespacePref != "") {
+        if (latestNamespacePref.isNotBlank()) {
             filters.add(SortByNamespace("date_added"))
             filters.add(DescendingOrder(true))
         }

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/model/Category.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/model/Category.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.extension.all.lanraragi.model
 
 data class Category(
     val id: String,
-    val last_used: Int,
+    val last_used: String,
     val name: String,
-    val pinned: Int
+    val pinned: String
 )

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/model/Category.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/model/Category.kt
@@ -1,0 +1,8 @@
+package eu.kanade.tachiyomi.extension.all.lanraragi.model
+
+data class Category(
+    val id: String,
+    val last_used: Int,
+    val name: String,
+    val pinned: Int
+)


### PR DESCRIPTION
Filters and pagination manipulation.
Latest now works as intended with accompanying new preferences.
API usage change to use its metadata endpoint and preserve WebView.

Categories are fetched from the server on `init {}` in a similar fashion to Komga.