### PR TITLE
Fix cannot open chapter after searching

### DIFF
--- a/src/id/komiku/build.gradle
+++ b/src/id/komiku/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komiku'
     pkgNameSuffix = 'id.komiku'
     extClass = '.Komiku'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
+++ b/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
@@ -79,7 +79,7 @@ class Komiku : ParsedHttpSource() {
     override fun searchMangaSelector() = popularMangaSelector()
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val url = HttpUrl.parse("$baseUrl/cari/page/$page/")?.newBuilder()!!.addQueryParameter("s", query)
+        val url = HttpUrl.parse("$baseUrl/pustaka/page/$page/")?.newBuilder()!!.addQueryParameter("s", query)
         (if (filters.isEmpty()) getFilterList() else filters).forEach { filter ->
             when (filter) {
                 is CategoryNames -> {


### PR DESCRIPTION
This update fixed problem on komiku that can't go into chapter when opened from searching. It seems that komiku.id change behavior of searching. Instead of page "cari" on the web, they use page "pustaka" now for manga list and also searching
