### PR TITLE
Exclude premium items from search results

### DIFF
--- a/src/en/doujins/build.gradle
+++ b/src/en/doujins/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Doujins'
     pkgNameSuffix = 'en.doujins'
     extClass = '.Doujins'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
+++ b/src/en/doujins/src/eu/kanade/tachiyomi/extension/en/doujins/Doujins.kt
@@ -149,7 +149,7 @@ class Doujins : HttpSource() {
 
         val pagination = document.select(".pagination").first()
         return MangasPage(
-            document.select("a.gallery-visited-from-favorites").map {
+            document.select("div:not(.premium-folder) > .thumbnail-doujin a.gallery-visited-from-favorites").map {
                 SManga.create().apply {
                     setUrlWithoutDomain(it.attr("href"))
                     title = it.select("div.title .text").text()


### PR DESCRIPTION
Premium content access via login is not yet supported for this extension. This fix excludes premium items from being included in search results.