### PR TITLE
Fix GManga Latest page error and crashing on older devices

### DIFF
--- a/src/ar/gmanga/build.gradle
+++ b/src/ar/gmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'GMANGA'
     pkgNameSuffix = 'ar.gmanga'
     extClass = '.Gmanga'
-    extVersionCode = 3
+    extVersionCode = 2
     libVersion = '1.2'
     containsNsfw = false
 }

--- a/src/ar/gmanga/build.gradle
+++ b/src/ar/gmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'GMANGA'
     pkgNameSuffix = 'ar.gmanga'
     extClass = '.Gmanga'
-    extVersionCode = 2
+    extVersionCode = 4
     libVersion = '1.2'
     containsNsfw = false
 }

--- a/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/Gmanga.kt
+++ b/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/Gmanga.kt
@@ -110,7 +110,7 @@ class Gmanga : ConfigurableSource, HttpSource() {
     }
 
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("$baseUrl/releases", headers)
+        return GET("$baseUrl/mangas/latest", headers)
     }
 
     override fun mangaDetailsParse(response: Response): SManga {

--- a/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/Gmanga.kt
+++ b/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/Gmanga.kt
@@ -101,8 +101,11 @@ class Gmanga : ConfigurableSource, HttpSource() {
                 SManga.create().apply {
                     url = "/mangas/${it["id"].asString}"
                     title = it["title"].asString
-                    val thumbnail = "medium_${it["cover"].asString.substringBeforeLast(".")}.webp"
-                    thumbnail_url = "https://media.$domain/uploads/manga/cover/${it["id"].asString}/$thumbnail"
+
+                    thumbnail_url = it["cover"].nullString?.let { coverFileName ->
+                        val thumbnail = "medium_${coverFileName.substringBeforeLast(".")}.webp"
+                        "https://media.$domain/uploads/manga/cover/${it["id"].asString}/$thumbnail"
+                    }
                 }
             },
             false

--- a/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/GmangaCryptoUtils.kt
+++ b/src/ar/gmanga/src/eu/kanade/tachiyomi/extension/ar/gmanga/GmangaCryptoUtils.kt
@@ -1,9 +1,7 @@
 package eu.kanade.tachiyomi.extension.ar.gmanga
 
-import android.annotation.TargetApi
-import android.os.Build
+import android.util.Base64
 import java.security.MessageDigest
-import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -36,14 +34,12 @@ private fun String.sha256(): String {
         .fold("", { str, it -> str + "%02x".format(it) })
 }
 
-@TargetApi(Build.VERSION_CODES.O)
 private fun String.aesDecrypt(secretKey: ByteArray, ivString: String): String {
-    val decoder = Base64.getDecoder()
     val c = Cipher.getInstance("AES/CBC/PKCS5Padding")
     val sk = SecretKeySpec(secretKey, "AES")
-    val iv = IvParameterSpec(decoder.decode(ivString.toByteArray(Charsets.UTF_8)))
+    val iv = IvParameterSpec(Base64.decode(ivString.toByteArray(Charsets.UTF_8), Base64.DEFAULT))
     c.init(Cipher.DECRYPT_MODE, sk, iv)
 
-    val byteStr = decoder.decode(this.toByteArray(Charsets.UTF_8))
+    val byteStr = Base64.decode(this.toByteArray(Charsets.UTF_8), Base64.DEFAULT)
     return String(c.doFinal(byteStr))
 }


### PR DESCRIPTION
Fixes #5331
- Uses `android.util.Base64` now which is available for lower API levels (thanks to @alimamahmoud for reporting and for the suggested fix)

Reverts #5497
- The previous URL was still fine, just that items without thumbnails were not handled properly hence the `JSON Null` error. Changing to `/release` doesn't make it work either and will require different parsing logic. This reverts that PR and adds handling for items with `null` thumbnails.