### PR TITLE
[Ru]Fix Mangalib conflicting directory names and manga details (J2K)

### DIFF
--- a/src/ru/libmanga/build.gradle
+++ b/src/ru/libmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaLib'
     pkgNameSuffix = 'ru.libmanga'
     extClass = '.LibManga'
-    extVersionCode = 29
+    extVersionCode = 30
     libVersion = '1.2'
 }
 

--- a/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
+++ b/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
@@ -163,8 +163,6 @@ class LibManga : ConfigurableSource, HttpSource() {
         }
 
         val genres = document.select(".media-tags > a").map { it.text() }
-
-        manga.title = document.select(".media-name__alt").text()
         manga.thumbnail_url = document.select(".media-sidebar__cover > img").attr("src")
         manga.author = body.select("div.media-info-list__title:contains(Автор) + div").text()
         manga.artist = body.select("div.media-info-list__title:contains(Художник) + div").text()


### PR DESCRIPTION
When the manga was opened, the original name from the catalog changed to an alternate one.
