### PR TITLE
Pufei: fix some pages, fix some covers, show author

### DIFF
--- a/src/zh/pufei/build.gradle
+++ b/src/zh/pufei/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Pufei'
     pkgNameSuffix = 'zh.pufei'
     extClass = '.Pufei'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
- Fix some pages (closes #4576): the latest chapter for one of the examples in the issue (氪金玩家) doesn't work on the site either, but this PR does fix the other example (魔王大人氪金中).
- Fix covers in manga list: covers weren't set when parsing manga list, so there were additional network calls that caused some time before all covers load
- Fix some covers in manga details: host in cover URLs was replaced to `http://i.youzipi.net/` that worked only when URL already uses this host. When URL uses another host - covers were broken
- Show author