### PR TITLE
Toomics: various fixes

### DIFF
--- a/src/all/toomics/build.gradle
+++ b/src/all/toomics/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Toomics'
     pkgNameSuffix = 'all.toomics'
     extClass = '.ToomicsFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
+++ b/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
@@ -118,6 +118,7 @@ abstract class ToomicsGlobal(
             .map { it.reversed() }
     }
 
+    // coin-type1 - free chapter, coin-type6 - already read chapter
     override fun chapterListSelector(): String = "li.normal_ep:has(.coin-type1, .coin-type6)"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {

--- a/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
+++ b/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
@@ -43,24 +43,23 @@ abstract class ToomicsGlobal(
         .add("User-Agent", USER_AGENT)
 
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$baseUrl/$siteLang/webtoon/free_all", headers)
+        return GET("$baseUrl/$siteLang/webtoon/favorite", headers)
     }
 
     // ToomicsGlobal does not have a popular list, so use recommended instead.
     override fun popularMangaSelector(): String = "li > div.visual"
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        element.select("a").let {
-            title = it.text()
-            setUrlWithoutDomain(it.attr("href"))
-        }
-        thumbnail_url = element.select("img").attr("abs:data-original")
+        title = element.select("h4[class$=title]").first().ownText()
+        // sometimes href contains "/ab/on" at the end and redirects to a chapter instead of manga
+        setUrlWithoutDomain(element.select("a").attr("href").removeSuffix("/ab/on"))
+        thumbnail_url = element.select("img").attr("src")
     }
 
     override fun popularMangaNextPageSelector(): String? = null
 
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("$baseUrl/$siteLang/webtoon/free", headers)
+        return GET("$baseUrl/$siteLang/webtoon/new_comics", headers)
     }
 
     override fun latestUpdatesSelector(): String = popularMangaSelector()
@@ -119,13 +118,13 @@ abstract class ToomicsGlobal(
             .map { it.reversed() }
     }
 
-    override fun chapterListSelector(): String = "li.normal_ep:has(.coin-type1)"
+    override fun chapterListSelector(): String = "li.normal_ep:has(.coin-type1, .coin-type6)"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val num = element.select("div.cell-num").text()
         val numText = if (num.isNotEmpty()) "$num - " else ""
 
-        name = numText + element.select("div.cell-title")?.first()?.ownText()
+        name = numText + element.select("div.cell-title strong")?.first()?.ownText()
         chapter_number = num.toFloatOrNull() ?: -1f
         date_upload = parseChapterDate(element.select("div.cell-time time").text()!!)
         scanlator = "Toomics"
@@ -135,10 +134,13 @@ abstract class ToomicsGlobal(
     }
 
     override fun pageListParse(document: Document): List<Page> {
+        if (document.select("div.section_age_verif").isNotEmpty())
+            throw Exception("Verify age via WebView")
+
         val url = document.select("head meta[property='og:url']").attr("content")
 
         return document.select("div[id^=load_image_] img")
-            .mapIndexed { i, el -> Page(i, url, el.attr("abs:data-original")) }
+            .mapIndexed { i, el -> Page(i, url, el.attr("data-src")) }
     }
 
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException("Not used")


### PR DESCRIPTION
Closes #4959
- New links to popular and latest
- Fix thumbnails in browse
- Fix sometimes no chapters found due to `/ab/on` at the end that redirects to a chapter instead of manga page
- Don't filter out chapters that user already have read
- Fix chapter names displaying only number
- Show corresponding error when a chapter requires age confirmation
- Fix pages not loading