### PR TITLE
Update NewToki extension to v1.2.21

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NewToki / ManaToki'
     pkgNameSuffix = 'ko.newtoki'
     extClass = '.NewTokiFactory'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/ManaToki.kt
@@ -230,7 +230,7 @@ class ManaToki(domainNumber: Long) : NewToki("ManaToki", "https://manatoki$domai
     private class SearchSortTypeList : Filter.Select<String>(
         "Sort",
         arrayOf(
-            "기본",
+            "기본(날짜순)",
             "인기순",
             "추천순",
             "업데이트순"

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -305,7 +305,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
             key = RATE_LIMIT_PERIOD_PREF_TITLE
             title = RATE_LIMIT_PERIOD_PREF_TITLE
             summary = RATE_LIMIT_PERIOD_PREF_SUMMARY
-            this.setDefaultValue(defaultRateLimitPeriod)
+            this.setDefaultValue(defaultRateLimitPeriod.toString())
             dialogTitle = RATE_LIMIT_PERIOD_PREF_TITLE
             dialogMessage = "Min 1 to Max 9, Invalid value will treat as $defaultRateLimitPeriod. Only Integer.\nDefault: $defaultRateLimitPeriod"
 
@@ -395,7 +395,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
             key = RATE_LIMIT_PERIOD_PREF_TITLE
             title = RATE_LIMIT_PERIOD_PREF_TITLE
             summary = RATE_LIMIT_PERIOD_PREF_SUMMARY
-            this.setDefaultValue(defaultRateLimitPeriod)
+            this.setDefaultValue(defaultRateLimitPeriod.toString())
             dialogTitle = RATE_LIMIT_PERIOD_PREF_TITLE
             dialogMessage = "Min 1 to Max 9, Invalid value will treat as $defaultRateLimitPeriod. Only Integer.\nDefault: $defaultRateLimitPeriod"
 
@@ -469,9 +469,10 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
         private const val RATE_LIMIT_PERIOD_PREF_TITLE = "Rate Limit Request Period Seconds"
         private const val RATE_LIMIT_PERIOD_PREF = "rateLimitPeriod"
         private const val RATE_LIMIT_PERIOD_PREF_SUMMARY =
-            "As Source is using Temporary IP ban system to who makes bunch of request, Requests are rate limited\n" +
+            "As Source is using Temporary IP ban system to who makes bunch of request, Some of requests are rate limited\n" +
                 "If you want to reduce limit, Use this option.\n" +
-                "Invalid value will treat as default $defaultRateLimitPeriod seconds. (Valid: Integer 1 ~ 9)`"
+                "Invalid value will treat as default $defaultRateLimitPeriod seconds.\n" +
+                "(Valid: Min 1 to Max 9)"
         private const val RATE_LIMIT_PERIOD_PREF_WARNING_INVALID_VALUE = "Invalid value detected. Treating as $defaultRateLimitPeriod..."
 
         const val PREFIX_ID_SEARCH = "id:"

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -440,10 +440,10 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     protected fun getExperimentLatest(): Boolean = preferences.getBoolean(EXPERIMENTAL_LATEST_PREF, false)
     protected fun getLatestWithDetail(): Boolean = preferences.getBoolean(EXPERIMENTAL_LATEST_WITH_DETAIL_PREF, false)
     private fun getRateLimitPeriod(): Long = try { // Check again as preference is bit weirdly buggy.
-        val v = preferences.getLong(RATE_LIMIT_PERIOD_PREF, 2L)
-        if (v in 1..9) v else 2
+        val v = preferences.getLong(RATE_LIMIT_PERIOD_PREF, defaultRateLimitPeriod)
+        if (v in 1..9) v else defaultRateLimitPeriod
     } catch (e: Exception) {
-        2
+        defaultRateLimitPeriod
     }
 
     companion object {
@@ -467,7 +467,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
                 "Still, It's experiment. Required to enable `Enable Latest (Experimental).`"
 
         // Settings: Rate Limit Period
-        private const val defaultRateLimitPeriod: Long = 2
+        private const val defaultRateLimitPeriod: Long = 2L
         private const val RATE_LIMIT_PERIOD_PREF_TITLE = "Rate Limit Request Period Seconds"
         private const val RATE_LIMIT_PERIOD_PREF = "rateLimitPeriod"
         private const val RATE_LIMIT_PERIOD_PREF_SUMMARY =

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -313,9 +313,10 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
                 try {
                     // Make sure to validate the value.
                     val p = (newValue as String).toLongOrNull(10)
-                    val value = p ?: defaultRateLimitPeriod
-                    if (p == null || (value < 1 || value > 10)) {
+                    var value = p ?: defaultRateLimitPeriod
+                    if (p == null || value !in 1..9) {
                         Toast.makeText(screen.context, RATE_LIMIT_PERIOD_PREF_WARNING_INVALID_VALUE, Toast.LENGTH_LONG).show()
+                        value = 2
                     }
                     val res = preferences.edit().putLong(RATE_LIMIT_PERIOD_PREF, value).commit()
                     Toast.makeText(screen.context, RESTART_TACHIYOMI, Toast.LENGTH_LONG).show()
@@ -402,9 +403,10 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
                 try {
                     // Make sure to validate the value.
                     val p = (newValue as String).toLongOrNull(10)
-                    val value = p ?: defaultRateLimitPeriod
-                    if (p == null || (value < 1 || value > 10)) {
+                    var value = p ?: defaultRateLimitPeriod
+                    if (p == null || value !in 1..9) {
                         Toast.makeText(screen.context, RATE_LIMIT_PERIOD_PREF_WARNING_INVALID_VALUE, Toast.LENGTH_LONG).show()
+                        value = 2
                     }
                     val res = preferences.edit().putLong(RATE_LIMIT_PERIOD_PREF, value).commit()
                     Toast.makeText(screen.context, RESTART_TACHIYOMI, Toast.LENGTH_LONG).show()
@@ -437,7 +439,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     protected fun getLatestWithDetail(): Boolean = preferences.getBoolean(EXPERIMENTAL_LATEST_WITH_DETAIL_PREF, false)
     private fun getRateLimitPeriod(): Long = try { // Check again as preference is bit buggy.
         val v = preferences.getLong(RATE_LIMIT_PERIOD_PREF, 2)
-        if (v < 1 || v > 10) v else 2
+        if (v in 1..9) v else 2
     } catch (e: Exception) {
         2
     }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -439,7 +439,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     private fun getPrefBaseUrl(): String = preferences.getString(BASE_URL_PREF, defaultBaseUrl)!!
     protected fun getExperimentLatest(): Boolean = preferences.getBoolean(EXPERIMENTAL_LATEST_PREF, false)
     protected fun getLatestWithDetail(): Boolean = preferences.getBoolean(EXPERIMENTAL_LATEST_WITH_DETAIL_PREF, false)
-    private fun getRateLimitPeriod(): Long = try { // Check again as preference is bit buggy.
+    private fun getRateLimitPeriod(): Long = try { // Check again as preference is bit weirdly buggy.
         val v = preferences.getLong(RATE_LIMIT_PERIOD_PREF, 2L)
         if (v in 1..9) v else 2
     } catch (e: Exception) {

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -151,7 +151,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
         val rawName = linkElement.ownText().trim()
 
         val chapter = SChapter.create()
-        chapter.setUrlWithoutDomain(linkElement.attr("href"))
+        chapter.url = getUrlWithoutDomainWithFallback(linkElement.attr("href"))
         chapter.chapter_number = parseChapterNumber(rawName)
         chapter.name = rawName
         chapter.date_upload = parseChapterDate(element.select(".wr-date").last().text().trim())
@@ -433,6 +433,24 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
             URI(orig).path
         } catch (e: URISyntaxException) {
             orig
+        }
+    }
+
+    // This is just replicate of original method but with fallback.
+    protected fun getUrlWithoutDomainWithFallback(orig: String): String {
+        return try {
+            val uri = URI(orig)
+            var out = uri.path
+            if (uri.query != null) {
+                out += "?" + uri.query
+            }
+            if (uri.fragment != null) {
+                out += "#" + uri.fragment
+            }
+            out
+        } catch (e: URISyntaxException) {
+            // fallback method. may not work.
+            orig.substringAfter(baseUrl)
         }
     }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -146,7 +146,7 @@ class NewTokiWebtoon : NewToki("NewToki", "https://newtoki$domainNumber.com", "w
     private class SearchSortTypeList : Filter.Select<String>(
         "Sort",
         arrayOf(
-            "기본",
+            "기본(업데이트순)",
             "인기순",
             "추천순",
         )


### PR DESCRIPTION
* Preference: Rate Limit Period added. (also closes #5934)
  - Default is 2. can reduce to 1 or increase to 9 as you want.
  - Since their system is bit weird. I didn't got ban on 1 sec, but #5934 says he got banned.
  - By this change, Default Rate Limit is 1 request per 1 second.
* Specify a default sort filter's setting.
  - Site says it's just default btw.
* Temp fix about uri parsing error (closes #5657)
  - This was not extension fault. According to [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt), Square bracket is not allowed on uri path.