### PR TITLE
Keenspot TwoKinds: Remove colon from source name to avoid downloading problems

### DIFF
--- a/src/en/keenspot/build.gradle
+++ b/src/en/keenspot/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'keenspot'
     pkgNameSuffix = 'en.keenspot'
     extClass = '.KeenspotFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/keenspot/src/eu/kanade/tachiyomi/extension/en/keenspot/TwoKinds.kt
+++ b/src/en/keenspot/src/eu/kanade/tachiyomi/extension/en/keenspot/TwoKinds.kt
@@ -15,13 +15,15 @@ import rx.Observable
 
 class TwoKinds : HttpSource() {
 
-    override val name = "Keenspot: TwoKinds"
+    override val name = "Keenspot TwoKinds"
 
     override val baseUrl = "https://twokinds.keenspot.com"
 
     override val lang = "en"
 
     override val supportsLatest: Boolean = false
+
+    override val id: Long = 3133607736276627986
 
     // the one and only manga entry
     fun mangaSinglePages(): SManga {


### PR DESCRIPTION
Closes #5191

It **will** create orphaned downloads for those, who already downloaded. Those users will need to rename the folder by removing the colon and restart the app after this.

But, it will fix downloads for those, who couldn't download because of the colon, e.g. #5191.