### PR TITLE
ComicExtra: Recursively fetch chapters

### DIFF
--- a/src/en/comicextra/build.gradle
+++ b/src/en/comicextra/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ComicExtra'
     pkgNameSuffix = 'en.comicextra'
     extClass = '.ComicExtra'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Resolves #5947

- Switch to recursive fetching to ensure all pages are processed
