### PR TITLE
Komiku: remove manga title in chapter name

### DIFF
--- a/src/id/komiku/build.gradle
+++ b/src/id/komiku/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komiku'
     pkgNameSuffix = 'id.komiku'
     extClass = '.Komiku'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
+++ b/src/id/komiku/src/eu/kanade/tachiyomi/extension/id/komiku/Komiku.kt
@@ -244,7 +244,7 @@ class Komiku : ParsedHttpSource() {
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.select("a").attr("href"))
-        name = element.select("a").attr("title")
+        name = element.select("a").text()
 
         val timeStamp = element.select("td.tanggalseries")
         if (timeStamp.text().contains("lalu")) {


### PR DESCRIPTION
if manga title contains number, it can cause issue to tracking