### PR TITLE
ReadManhwa: use popular for all time instead of week, minor changes

### DIFF
--- a/src/en/readmanhwa/build.gradle
+++ b/src/en/readmanhwa/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ReadManhwa'
     pkgNameSuffix = 'en.readmanhwa'
     extClass = '.ReadManhwa'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/readmanhwa/src/eu/kanade/tachiyomi/extension/en/readmanhwa/ReadManhwa.kt
+++ b/src/en/readmanhwa/src/eu/kanade/tachiyomi/extension/en/readmanhwa/ReadManhwa.kt
@@ -81,7 +81,7 @@ class ReadManhwa : ConfigurableSource, HttpSource() {
     // Popular
 
     override fun popularMangaRequest(page: Int): Request {
-        return GET(getMangaUrl("$baseUrl/api/comics?per_page=36&page=$page&q=&sort=popularity&order=desc&duration=week"), headers)
+        return GET(getMangaUrl("$baseUrl/api/comics?per_page=36&page=$page&q=&sort=popularity&order=desc&duration=all"), headers)
     }
 
     override fun popularMangaParse(response: Response): MangasPage = parseMangaFromJson(response)
@@ -102,7 +102,6 @@ class ReadManhwa : ConfigurableSource, HttpSource() {
         val url = HttpUrl.parse("$baseUrl/api/comics")!!.newBuilder()
             .addQueryParameter("per_page", "36")
             .addQueryParameter("page", page.toString())
-            .addQueryParameter("order", "desc")
             .addQueryParameter("q", query)
             .addQueryParameter("nsfw", enableNsfw.toString())
 
@@ -136,13 +135,8 @@ class ReadManhwa : ConfigurableSource, HttpSource() {
                     }
                 }
                 is OrderBy -> {
-                    var orderby = ""
-                    if (filter.state!!.ascending) {
-                        orderby = "asc"
-                    } else {
-                        orderby = "desc"
-                    }
-                    var sort = arrayOf("uploaded_at", "title", "pages", "favorites", "popularity")[filter.state!!.index]
+                    val orderby = if (filter.state!!.ascending) "asc" else "desc"
+                    val sort = arrayOf("uploaded_at", "title", "pages", "favorites", "popularity")[filter.state!!.index]
                     url.addQueryParameter("sort", sort)
                     url.addQueryParameter("order", orderby)
                 }


### PR DESCRIPTION
- Use popular for all time instead of week. Closes #5765. Why it didn't work before: the site itself doesn't have results for popular by week that was used by default in the extension. Why switching nsfw flag fixed it: changing filter caused to apply all parameters from filter, where order by date for all time is used by default.
- Remove repeated `order` parameter.
- Fix some warnings in lines 139-145