### PR TITLE
MangaLib: notify user when manga redirects to home page

### DIFF
--- a/src/ru/libmanga/build.gradle
+++ b/src/ru/libmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaLib'
     pkgNameSuffix = 'ru.libmanga'
     extClass = '.LibManga'
-    extVersionCode = 33
+    extVersionCode = 34
     libVersion = '1.2'
 }
 

--- a/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
+++ b/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
@@ -146,6 +146,10 @@ class LibManga : ConfigurableSource, HttpSource() {
 
     override fun mangaDetailsParse(response: Response): SManga {
         val document = response.asJsoup()
+
+        if (document.select("body[data-page=home]").isNotEmpty())
+            throw Exception("Can't open manga. Try log in via WebView")
+
         val manga = SManga.create()
 
         if (document.html().contains("Манга удалена по просьбе правообладателей")) {


### PR DESCRIPTION
Closes #5933

`response.isRedirect` didn't work for some reason and also there is a chance that it would redirect to correct manga page, so I did it with a selector