### PR TITLE
MangaMainac: filter out latest chapter if it's not released yet, update URLs

### DIFF
--- a/src/en/mangamainac/build.gradle
+++ b/src/en/mangamainac/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaMainac'
     pkgNameSuffix = 'en.mangamainac'
     extClass = '.MangaMainac'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
- filter unreleased chapters (the same as in #6050)
- update two URLs (old manga in library will still work with http or redirect)

No opened issues

Side note for future: `The Promised Neverland` and `The Quintessential Quintuplets` sites are down, I couldn't find new links to them and if they will remain like this for long time, they should be removed 