### PR TITLE
fix Mangalife chapter numbers

### DIFF
--- a/src/en/mangalife/build.gradle
+++ b/src/en/mangalife/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaLife'
     pkgNameSuffix = 'en.mangalife'
     extClass = '.MangaLife'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '1.2'
 }
 

--- a/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
+++ b/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
@@ -220,8 +220,10 @@ class MangaLife : HttpSource() {
         return "-chapter-$n$index$suffix.html"
     }
 
-    private fun chapterImage(e: String): String {
-        val a = e.substring(1, e.length - 1)
+    private val chapterImageRegex = Regex("""^0+""")
+
+    private fun chapterImage(e: String, cleanString: Boolean = false): String {
+        val a = e.substring(1, e.length - 1).let { if (cleanString) it.replace(chapterImageRegex, "") else it }
         val b = e.substring(e.length - 1).toInt()
         return if (b == 0) {
             a
@@ -237,7 +239,7 @@ class MangaLife : HttpSource() {
         return gson.fromJson<JsonArray>(vmChapters).map { json ->
             val indexChapter = json["Chapter"].string
             SChapter.create().apply {
-                name = json["ChapterName"].nullString.let { if (it.isNullOrEmpty()) "${json["Type"].string} ${chapterImage(indexChapter)}" else it }
+                name = json["ChapterName"].nullString.let { if (it.isNullOrEmpty()) "${json["Type"].string} ${chapterImage(indexChapter, true)}" else it }
                 url = "/read-online/" + response.request().url().toString().substringAfter("/manga/") + chapterURLEncode(indexChapter)
                 date_upload = try {
                     json["Date"].nullString?.let { dateFormat.parse("$it +0600")?.time } ?: 0


### PR DESCRIPTION
This PR changes how chapter number is shown in MangaLife
chapterRegex was taken from MangaSee extension code (which share most of their code already)
Have been using the extension for some time and its working fine


| before | after |
|----|---|
| "Chapter 0142" | "Chapter 142" |
| ![Screenshot_1614798631](https://user-images.githubusercontent.com/72807749/110000456-4f2eb100-7d39-11eb-86f5-3bef13f34f87.png) | ![Screenshot_1614803771](https://user-images.githubusercontent.com/72807749/110000460-50f87480-7d39-11eb-87b2-63cc43a34fbe.png) | 