### PR TITLE
Fixed crash on startup when host address is empty

### DIFF
--- a/src/all/mango/build.gradle
+++ b/src/all/mango/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mango'
     pkgNameSuffix = 'all.mango'
     extClass = '.Mango'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/all/mango/src/eu/kanade/tachiyomi/extension/all/mango/Mango.kt
+++ b/src/all/mango/src/eu/kanade/tachiyomi/extension/all/mango/Mango.kt
@@ -306,7 +306,7 @@ class Mango : ConfigurableSource, HttpSource() {
     // We strip the last slash since we will append it above
     private fun getPrefBaseUrl(): String {
         var path = preferences.getString(ADDRESS_TITLE, ADDRESS_DEFAULT)!!
-        if (path.last() == '/') {
+        if (path.isNotEmpty() && path.last() == '/') {
             path = path.substring(0, path.length - 1)
         }
         return path


### PR DESCRIPTION
Would crash on startup if the address field is empty since it has zero length so you can't get a `.last()`.