### PR TITLE
Add support for Guya proxy.

### DIFF
--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
The use-case is niche (especially since many of the proxied sites have Tachi extensions already), but we're hosting a Kaguya re-read event on the Kaguya Discord, and we'll be using our proxy to time the weekly releases [here](https://guya.moe/proxy/gist/Kaguya-Reread/). This PR adds support for the proxy using search with the schema of `proxy:<source>/<slug>`.

For example, `proxy:gist/Kaguya-Reread` for the above. Our proxy also supports Imgur, so, for example, `proxy:imgur/2FzJ0Y9` works. This might address #5631, but the functionality is rather nested. 