### PR TITLE
LANraragi: Random item, clear new status

### DIFF
--- a/src/all/lanraragi/build.gradle
+++ b/src/all/lanraragi/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'LANraragi'
     pkgNameSuffix = 'all.lanraragi'
     extClass = '.LANraragi'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -532,6 +532,15 @@ open class LANraragi : ConfigurableSource, HttpSource() {
     private val clientNoFollow: OkHttpClient = client.newBuilder().followRedirects(false).build()
 
     init {
+        // Save users a Random refresh in the extension and from Library
+        Single.fromCallable { getRandomIDResponse() }
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { randomArchiveID = getRandomID(it) },
+                {}
+            )
+
         Single.fromCallable {
             client.newCall(GET("$baseUrl/api/categories", headers)).execute()
         }

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -94,6 +94,16 @@ open class LANraragi : ConfigurableSource, HttpSource() {
         val archive = gson.fromJson<Archive>(response.body()!!.string())
         val uri = getApiUriBuilder("/api/archives/${archive.arcid}/extract")
 
+        // Replicate old behavior and unset "isnew" for the archive.
+        if (archive.isnew == "true") {
+            val clearNew = Request.Builder()
+                .url("$baseUrl/api/archives/${archive.arcid}/isnew")
+                .delete()
+                .build()
+
+            client.newCall(clearNew).execute()
+        }
+
         return listOf(
             SChapter.create().apply {
                 val uriBuild = uri.build()

--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -57,9 +57,6 @@ open class LANraragi : ConfigurableSource, HttpSource() {
 
     private var randomArchiveID: String = ""
 
-    // AZ detection to avoid random ID desync
-    private var tachiAZ: Int = 0
-
     override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
         val id = if (manga.url == "/random") randomArchiveID else getReaderId(manga.url)
         val uri = getApiUriBuilder("/api/archives/$id/metadata").build()
@@ -83,19 +80,11 @@ open class LANraragi : ConfigurableSource, HttpSource() {
     override fun mangaDetailsParse(response: Response): SManga {
         val archive = gson.fromJson<Archive>(response.body()!!.string())
 
-        // chapterListRequest didn't happen since only AZ's info tab was updated
-        if (tachiAZ == 0) tachiAZ = 1
-
         return archiveToSManga(archive)
     }
 
     override fun chapterListRequest(manga: SManga): Request {
-        // In every other situation this beats mangaDetailsParse and can't be AZ
-        if (tachiAZ == 0) tachiAZ = 2
-
-        val id = if (manga.url == "/random") {
-            if (tachiAZ == 1) getThumbnailId(manga.thumbnail_url!!) else randomArchiveID
-        } else getReaderId(manga.url)
+        val id = if (manga.url == "/random") randomArchiveID else getReaderId(manga.url)
         val uri = getApiUriBuilder("/api/archives/$id/metadata").build()
 
         return GET(uri.toString(), headers)


### PR DESCRIPTION
 - Adds a "Random" entry to popular's MangasPage, assuming nothing else prevents it.
 - Clears an archive's new status on the server similar to two versions ago before moving to API endpoints.
   - The web reader happened to be taking care of it