### PR TITLE
MangaLife, MangaSee: revert temporary fixes, show error about blocking

### DIFF
--- a/src/en/mangalife/build.gradle
+++ b/src/en/mangalife/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaLife'
     pkgNameSuffix = 'en.mangalife'
     extClass = '.MangaLife'
-    extVersionCode = 14
+    extVersionCode = 15
     libVersion = '1.2'
 }
 

--- a/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
+++ b/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
@@ -41,7 +41,7 @@ class MangaLife : HttpSource() {
 
     override val supportsLatest = true
 
-    private val rateLimitInterceptor = RateLimitInterceptor(1, 2)
+    private val rateLimitInterceptor = RateLimitInterceptor(1)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(rateLimitInterceptor)
@@ -264,7 +264,13 @@ class MangaLife : HttpSource() {
 
         val pageTotal = curChapter["Page"].string.toInt()
 
-        val host = "https://" + script.substringAfter("vm.justgiveupalready = \"").substringBefore("\"")
+        val host = "https://" +
+            script
+                .substringAfter("vm.CurPathName = \"", "")
+                .substringBefore("\"")
+                .also { if (it.isEmpty())
+                    throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
+                }
         val titleURI = script.substringAfter("vm.IndexName = \"").substringBefore("\"")
         val seasonURI = curChapter["Directory"].string
             .let { if (it.isEmpty()) "" else "$it/" }

--- a/src/en/mangasee/build.gradle
+++ b/src/en/mangasee/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangasee'
     pkgNameSuffix = 'en.mangasee'
     extClass = '.Mangasee'
-    extVersionCode = 18
+    extVersionCode = 19
     libVersion = '1.2'
 }
 

--- a/src/en/mangasee/src/eu/kanade/tachiyomi/extension/en/mangasee/Mangasee.kt
+++ b/src/en/mangasee/src/eu/kanade/tachiyomi/extension/en/mangasee/Mangasee.kt
@@ -44,7 +44,7 @@ class Mangasee : HttpSource() {
 
     override val supportsLatest = true
 
-    private val rateLimitInterceptor = RateLimitInterceptor(1, 2)
+    private val rateLimitInterceptor = RateLimitInterceptor(1)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .addNetworkInterceptor(rateLimitInterceptor)
@@ -268,7 +268,13 @@ class Mangasee : HttpSource() {
 
         val pageTotal = curChapter["Page"].string.toInt()
 
-        val host = "https://" + script.substringAfter("vm.justgiveupalready = \"").substringBefore("\"")
+        val host = "https://" +
+            script
+                .substringAfter("vm.CurPathName = \"", "")
+                .substringBefore("\"")
+                .also { if (it.isEmpty())
+                    throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
+                }
         val titleURI = script.substringAfter("vm.IndexName = \"").substringBefore("\"")
         val seasonURI = curChapter["Directory"].string
             .let { if (it.isEmpty()) "" else "$it/" }


### PR DESCRIPTION
It won't work right now, but:
- Users will see why it doesn't work.
- It will work as soon as they stop blocking tachi (tested with current variable name). Here is the post where sites' owner tells about unblocking: https://mangasee123.com/discussion/post.php?id=9870704