### PR TITLE
Manga mutiny: chapter number fix + closing responses

### DIFF
--- a/src/en/mangamutiny/build.gradle
+++ b/src/en/mangamutiny/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Manga Mutiny'
     pkgNameSuffix = "en.mangamutiny"
     extClass = '.MangaMutiny'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
@@ -96,9 +96,9 @@ class MangaMutiny : HttpSource() {
                     }
                 )
             }
-        }
 
-        // chapterList.sortByDescending { it.chapter_number }
+            responseBody.close()
+        }
 
         return chapterList
     }
@@ -181,6 +181,8 @@ class MangaMutiny : HttpSource() {
                 genre = rootNode.get("tags").asJsonArray
                     .joinToString { singleGenre -> singleGenre.asString }
             }
+
+            responseBody.close()
         }
 
         return manga
@@ -215,6 +217,8 @@ class MangaMutiny : HttpSource() {
             for (i in 0 until images.size()) {
                 pageList.add(Page(i, "", chapterUrl + images[i].asString))
             }
+
+            responseBody.close()
         }
 
         return pageList

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
@@ -75,7 +75,7 @@ class MangaMutiny : HttpSource() {
         mangaDetailsRequestCommon(manga, false)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val chapterList = ArrayList<SChapter>()
+        val chapterList = mutableListOf<SChapter>()
         val responseBody = response.body()
 
         if (responseBody != null) {
@@ -89,18 +89,27 @@ class MangaMutiny : HttpSource() {
                         name = chapterTitleBuilder(singleChapterJsonObject)
                         url = singleChapterJsonObject.get("slug").asString
                         date_upload = parseDate(singleChapterJsonObject.get("releasedAt").asString)
+
+                        chapterNumberBuilder(singleChapterJsonObject)?.let { chapterNumber ->
+                            chapter_number = chapterNumber
+                        }
                     }
                 )
             }
         }
 
+        // chapterList.sortByDescending { it.chapter_number }
+
         return chapterList
     }
+
+    private fun chapterNumberBuilder(rootNode: JsonObject): Float? =
+        rootNode.getNullable("chapter")?.asFloat
 
     private fun chapterTitleBuilder(rootNode: JsonObject): String {
         val volume = rootNode.getNullable("volume")?.asInt
 
-        val chapter = rootNode.getNullable("chapter")?.asInt
+        val chapter = rootNode.getNullable("chapter")?.asFloat
 
         val textTitle = rootNode.getNullable("title")?.asString
 


### PR DESCRIPTION
- Fix for #6149 (tested it with the Anilist tracker and chapters are tracked correctly with the changes of this PR)
- Sub-chapters (e.g. "1.0", "1.1", "1.2") are now recognizable by their chapter name
- closing some response bodies

Note: For mangas in the library users have to refresh the chapter lists once in order for the new chapter numbers to take effect. Performing a global update or updating the individual Manga Mutiny mangas should do the trick.