### PR TITLE
Mangadex: Add status parsing for completed titles

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 105
+    extVersionCode = 106
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -700,6 +700,8 @@ abstract class MangaDex(
 
     private fun parseStatus(status: Int) = when (status) {
         1 -> SManga.ONGOING
+        2 -> SManga.COMPLETED
+        // TODO: Missing SManga values for Mangadex's API status values 3 (Cancelled) and 4 (Hiatus)
         else -> SManga.UNKNOWN
     }
 


### PR DESCRIPTION
Status 2 is of manga that is finished, think this should work fine? Can't currently build to test it though, if someone could confirm this being the proper solution and building properly it'd be appreciated.

Status 3 (Cancelled) and 4 (Hiatus) aren't supported in the extension itself, so those will keep saying Unknown Status for the time being.