### PR TITLE
remove Gourmet Scans from Madara multisrc

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -59,7 +59,6 @@ class MadaraGenerator : ThemeSourceGenerator {
             SingleLang("Furio Scans", "https://furioscans.com", "pt-BR"),
             SingleLang("موقع لترجمة المانجا", "https://golden-manga.com", "ar", className = "GoldenManga"),
             SingleLang("Graze Scans", "https://grazescans.com/", "en"),
-            SingleLang("Gourmet Scans", "https://gourmetscans.net/", "en"),
             SingleLang("GuncelManga", "https://guncelmanga.com", "tr"),
             SingleLang("Hero Manhua", "https://heromanhua.com", "en"),
             SingleLang("Heroz Scanlation", "https://herozscans.com", "en"),


### PR DESCRIPTION
the extensions was removed as per the scanlation site's request

Closes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/6192