### PR TITLE
Mangairo: new search path, remove extra slash

### DIFF
--- a/multisrc/overrides/mangabox/mangairo/src/Mangairo.kt
+++ b/multisrc/overrides/mangabox/mangairo/src/Mangairo.kt
@@ -9,12 +9,12 @@ import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class Mangairo : MangaBox("Mangairo", "https://h.mangairo.com/", "en", SimpleDateFormat("MMM-dd-yy", Locale.ENGLISH)) {
+class Mangairo : MangaBox("Mangairo", "https://h.mangairo.com", "en", SimpleDateFormat("MMM-dd-yy", Locale.ENGLISH)) {
     override val popularUrlPath = "manga-list/type-topview/ctg-all/state-all/page-"
     override fun popularMangaSelector() = "div.story-item"
     override val latestUrlPath = "manga-list/type-latest/ctg-all/state-all/page-"
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/$simpleQueryPath${normalizeSearchQuery(query)}?page=$page", headers)
+        return GET("$baseUrl/list/$simpleQueryPath${normalizeSearchQuery(query)}?page=$page", headers)
     }
 
     override fun searchMangaSelector() = "div.story-item"

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangabox/MangaBoxGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangabox/MangaBoxGenerator.kt
@@ -16,7 +16,7 @@ class MangaBoxGenerator : ThemeSourceGenerator {
         SingleLang("Manganelo", "https://manganelo.com", "en"),
         SingleLang("Mangabat", "https://m.mangabat.com", "en", overrideVersionCode = 4),
         SingleLang("Mangakakalots (unoriginal)", "https://mangakakalots.com", "en", className = "Mangakakalots", pkgName = "mangakakalots"),
-        SingleLang("Mangairo", "https://h.mangairo.com/", "en", overrideVersionCode = 2),
+        SingleLang("Mangairo", "https://h.mangairo.com", "en", overrideVersionCode = 3),
     )
 
     companion object {


### PR DESCRIPTION
- New search path. Closes #6202.
- Remove extra slash. It didn't cause any issues, but all links had 2 slashes after the domain.