### PR TITLE
MangaLife/See: search alt names, trim search

### DIFF
--- a/src/en/mangalife/build.gradle
+++ b/src/en/mangalife/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaLife'
     pkgNameSuffix = 'en.mangalife'
     extClass = '.MangaLife'
-    extVersionCode = 16
+    extVersionCode = 17
     libVersion = '1.2'
 }
 

--- a/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
+++ b/src/en/mangalife/src/eu/kanade/tachiyomi/extension/en/mangalife/MangaLife.kt
@@ -144,8 +144,12 @@ class MangaLife : HttpSource() {
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = popularMangaRequest(1)
 
     private fun searchMangaParse(response: Response, query: String, filters: FilterList): MangasPage {
+        val trimmedQuery = query.trim()
         directory = gson.fromJson<JsonArray>(directoryFromResponse(response))
-            .filter { it["s"].string.contains(query, ignoreCase = true) }
+            .filter {
+                it["s"].string.contains(trimmedQuery, ignoreCase = true) or
+                    it["al"].asJsonArray.any { altName -> altName.string.contains(trimmedQuery, ignoreCase = true) }
+            }
 
         val genres = mutableListOf<String>()
         val genresNo = mutableListOf<String>()
@@ -268,8 +272,9 @@ class MangaLife : HttpSource() {
             script
                 .substringAfter("vm.CurPathName = \"", "")
                 .substringBefore("\"")
-                .also { if (it.isEmpty())
-                    throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
+                .also {
+                    if (it.isEmpty())
+                        throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
                 }
         val titleURI = script.substringAfter("vm.IndexName = \"").substringBefore("\"")
         val seasonURI = curChapter["Directory"].string

--- a/src/en/mangasee/build.gradle
+++ b/src/en/mangasee/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangasee'
     pkgNameSuffix = 'en.mangasee'
     extClass = '.Mangasee'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/en/mangasee/src/eu/kanade/tachiyomi/extension/en/mangasee/Mangasee.kt
+++ b/src/en/mangasee/src/eu/kanade/tachiyomi/extension/en/mangasee/Mangasee.kt
@@ -147,8 +147,12 @@ class Mangasee : HttpSource() {
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = popularMangaRequest(1)
 
     private fun searchMangaParse(response: Response, query: String, filters: FilterList): MangasPage {
+        val trimmedQuery = query.trim()
         directory = gson.fromJson<JsonArray>(directoryFromResponse(response))
-            .filter { it["s"].string.contains(query, ignoreCase = true) }
+            .filter {
+                it["s"].string.contains(trimmedQuery, ignoreCase = true) or
+                    it["al"].asJsonArray.any { altName -> altName.string.contains(trimmedQuery, ignoreCase = true) }
+            }
 
         val genres = mutableListOf<String>()
         val genresNo = mutableListOf<String>()
@@ -272,8 +276,9 @@ class Mangasee : HttpSource() {
             script
                 .substringAfter("vm.CurPathName = \"", "")
                 .substringBefore("\"")
-                .also { if (it.isEmpty())
-                    throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
+                .also {
+                    if (it.isEmpty())
+                        throw Exception("$name is overloaded and blocking Tachiyomi right now. Wait for unblock.")
                 }
         val titleURI = script.substringAfter("vm.IndexName = \"").substringBefore("\"")
         val seasonURI = curChapter["Directory"].string


### PR DESCRIPTION
- Consider alternative names. Closes #6259.
- Trim search. It's trimmed in browser, but in tachi it would show no results with extra spaces. No opened issue.
- Just noticed that AS formatted code, so whatever.