### PR TITLE
Updated Bato.to supported languages list

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Bato.to'
     pkgNameSuffix = 'all.batoto'
     extClass = '.BatoToFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoToFactory.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoToFactory.kt
@@ -10,6 +10,8 @@ class BatoToFactory : SourceFactory {
 }
 
 private val languages = listOf(
+    //commented langueges do currently not exist on Bato.to but haven in the past
+    Pair("all",""),
     Pair("ar", "ar"),
     Pair("bg", "bg"),
     Pair("cs", "cs"),
@@ -17,6 +19,7 @@ private val languages = listOf(
     Pair("de", "de"),
     Pair("el", "el"),
     Pair("en", "en"),
+    Pair("en_us", "en_us"),
     Pair("es", "es"),
     Pair("es-419", "es_419"),
     Pair("eu", "eu"),
@@ -25,14 +28,14 @@ private val languages = listOf(
     Pair("fil", "fil"),
     Pair("fr", "fr"),
     Pair("he", "he"),
-    Pair("hi", "hi"),
+    //Pair("hi", "hi"),
     Pair("hr", "hr"),
     Pair("hu", "hu"),
     Pair("id", "id"),
     Pair("it", "it"),
     Pair("ja", "ja"),
     Pair("ko", "ko"),
-    Pair("ku", "ku"),
+    //Pair("ku", "ku"),
     Pair("ml", "ml"),
     Pair("mn", "mn"),
     Pair("ms", "ms"),
@@ -49,7 +52,7 @@ private val languages = listOf(
     Pair("tr", "tr"),
     Pair("uk", "uk"),
     Pair("vi", "vi"),
-    Pair("xh", "xh"),
+    //Pair("xh", "xh"),
     Pair("zh", "zh"),
     Pair("zh-rHK", "zh_hk"),
     Pair("zh-rTW", "zh_tw"),


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
added en_us and unfiltered to language list
removed xh, hi and ku from language list
