### PR TITLE
Add intent for Guya proxies

### DIFF
--- a/src/en/guya/AndroidManifest.xml
+++ b/src/en/guya/AndroidManifest.xml
@@ -17,6 +17,11 @@
                     android:host="guya.moe"
                     android:pathPattern="/read/manga/..*"
                     android:scheme="https" />
+
+                <data
+                    android:host="guya.moe"
+                    android:pathPattern="/proxy/..*"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
     </application>

--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '1.2'
 }
 

--- a/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
+++ b/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
@@ -19,12 +19,24 @@ class GuyaUrlActivity : Activity() {
         super.onCreate(savedInstanceState)
         val pathSegments = intent?.data?.pathSegments
         if (pathSegments != null && pathSegments.size >= 3) {
-            val slug = pathSegments[2]
+            Log.d("GuyaUrlActivity", pathSegments[0])
+
+            val query = when (pathSegments[0]) {
+                "proxy" -> {
+                    val source = pathSegments[1]
+                    val id = pathSegments[2]
+                    "${Guya.PROXY_PREFIX}$source/$id"
+                }
+                else -> {
+                    val slug = pathSegments[2]
+                    "${Guya.SLUG_PREFIX}$slug"
+                }
+            }
 
             // Gotta do it like this since slug title != actual title
             val mainIntent = Intent().apply {
                 action = "eu.kanade.tachiyomi.SEARCH"
-                putExtra("query", "${Guya.SLUG_PREFIX}$slug")
+                putExtra("query", query)
                 putExtra("filter", packageName)
             }
 


### PR DESCRIPTION
Adds intent filter for Guya proxy links, so one doesn't manually need to type for example `proxy:imgur/aigznZt`.