### PR TITLE
xCaliBR Scans: fix pages, use https

### DIFF
--- a/multisrc/overrides/wpmangastream/xcalibrscans/src/xCaliBRScans.kt
+++ b/multisrc/overrides/wpmangastream/xcalibrscans/src/xCaliBRScans.kt
@@ -2,10 +2,12 @@ package eu.kanade.tachiyomi.extension.en.xcalibrscans
 
 import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.multisrc.wpmangastream.WPMangaStream
+import eu.kanade.tachiyomi.source.model.Page
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
 import java.util.concurrent.TimeUnit
 
-class xCaliBRScans : WPMangaStream("xCaliBR Scans", "http://xcalibrscans.com", "en") {
+class xCaliBRScans : WPMangaStream("xCaliBR Scans", "https://xcalibrscans.com", "en") {
     private val rateLimitInterceptor = RateLimitInterceptor(2)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
@@ -13,5 +15,10 @@ class xCaliBRScans : WPMangaStream("xCaliBR Scans", "http://xcalibrscans.com", "
         .readTimeout(30, TimeUnit.SECONDS)
         .addNetworkInterceptor(rateLimitInterceptor)
         .build()
+
+    override fun pageListParse(document: Document): List<Page> {
+        return document.select(pageSelector)
+            .mapIndexed { i, img -> Page(i, "", img.attr("data-src")) }
+    }
 
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
@@ -45,7 +45,7 @@ class WPMangaStreamGenerator : ThemeSourceGenerator {
             SingleLang("Silence Scan", "https://silencescan.net", "pt-BR"),
             SingleLang("Kuma Scans (Kuma Translation)", "https://kumascans.com", "en", className = "KumaScans"),
             SingleLang("Tempest Manga", "https://manga.tempestfansub.com", "tr"),
-            SingleLang("xCaliBR Scans", "http://xcalibrscans.com", "en"),
+            SingleLang("xCaliBR Scans", "https://xcalibrscans.com", "en", overrideVersionCode = 1),
             SingleLang("NoxSubs", "https://noxsubs.com", "tr"),
             SingleLang("World Romance Translation", "https://wrt.my.id/", "id", overrideVersionCode = 1),
             SingleLang("The Apollo Team", "https://theapollo.team", "en"),


### PR DESCRIPTION
- Fix pages, closes #6316.
- Use HTTPS instead of HTTP.
