### PR TITLE
[Komga] ignore dns over https

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.23
+
+Minimum Komga version required: `0.75.0`
+
+### Features
+
+* ignore DNS over HTTPS so it can reach IP addresses
+
 ## 1.2.22
 
 Minimum Komga version required: `0.75.0`

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,13 +5,13 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 22
+    extVersionCode = 23
     libVersion = '1.2'
 }
 
 dependencies {
     implementation 'io.reactivex:rxandroid:1.2.1'
-    implementation 'io.reactivex:rxjava:1.3.6'
+    implementation 'io.reactivex:rxjava:1.3.8'
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
This will use the System DNS in the network client, effectively ignoring the DNS over HTTPS setting of Tachiyomi. DoH prevents reaching local IP addresses, since they cannot be resolved by the DNS.

Could also be used for Mango and Lanraragi.