### PR TITLE
MangaMutiny: chapter number in chapter name improvement

### DIFF
--- a/src/en/mangamutiny/build.gradle
+++ b/src/en/mangamutiny/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Manga Mutiny'
     pkgNameSuffix = "en.mangamutiny"
     extClass = '.MangaMutiny'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
- small change to make chapter numbers in chapter names lose trailing `.0`
- don't recreate the SimpleDateFormatter for every parsed chapter. Declaring and initializing it once is enough.