### PR TITLE
Fix for the multi-sources not being generated properly

### DIFF
--- a/multisrc/build.gradle.kts
+++ b/multisrc/build.gradle.kts
@@ -1,6 +1,5 @@
 import java.io.BufferedReader
 import java.io.InputStreamReader
-import java.util.concurrent.TimeUnit
 
 plugins {
     id("com.android.library")
@@ -28,22 +27,25 @@ tasks {
     val generateExtensions by registering {
         doLast {
             val isWindows = System.getProperty("os.name").toString().toLowerCase().contains("win")
-            val classPath = (configurations.debugCompileOnly.get().asFileTree.toList() +
+            var classPath = (configurations.debugCompileOnly.get().asFileTree.toList() +
                 listOf(
                     configurations.androidApis.get().asFileTree.first().absolutePath, // android.jar path
                     "$projectDir/build/intermediates/aar_main_jar/debug/classes.jar" // jar made from this module
                 ))
                 .joinToString(if (isWindows) ";" else ":")
-            val javaPath = "${System.getProperty("java.home")}/bin/java"
+
+            var javaPath = "${System.getProperty("java.home")}/bin/java"
 
             val mainClass = "generator.GeneratorMainKt" // Main class we want to execute
 
-            val javaCommand = if (isWindows) {
-                "\"$javaPath\" -classpath $classPath $mainClass".replace("/", "\\")
-            } else {
-                "$javaPath -classpath $classPath $mainClass"
+            if (isWindows) {
+                classPath = classPath.replace("/", "\\")
+                javaPath = javaPath.replace("/", "\\")
             }
-            val javaProcess = Runtime.getRuntime().exec(javaCommand)
+
+            val javaProcess = ProcessBuilder()
+                .directory(null).command(javaPath, "-classpath", classPath, mainClass)
+                .redirectErrorStream(true).start()
 
             val inputStreamReader = InputStreamReader(javaProcess.inputStream)
             val bufferedReader = BufferedReader(inputStreamReader)

--- a/multisrc/build.gradle.kts
+++ b/multisrc/build.gradle.kts
@@ -1,3 +1,7 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.concurrent.TimeUnit
+
 plugins {
     id("com.android.library")
     kotlin("android")
@@ -40,6 +44,18 @@ tasks {
                 "$javaPath -classpath $classPath $mainClass"
             }
             val javaProcess = Runtime.getRuntime().exec(javaCommand)
+
+            val inputStreamReader = InputStreamReader(javaProcess.inputStream)
+            val bufferedReader = BufferedReader(inputStreamReader)
+
+            var s: String?
+            while (bufferedReader.readLine().also { s = it } != null) {
+                logger.info(s)
+            }
+
+            bufferedReader.close()
+            inputStreamReader.close()
+
             val exitCode = javaProcess.waitFor()
             if (exitCode != 0) {
                 throw Exception("Java process failed with exit code: $exitCode")


### PR DESCRIPTION
As described here https://www.infoworld.com/article/2071275/when-runtime-exec---won-t.html under "Listing 4.2 BadExecJavac2.java" the limited buffer size of the standard input associated with the sub-process can cause problems with the Runtime exec method.

Consuming what the sub-process outputs allows for the process to finish (+ if you enable log level info you get some nice debug information).

I've tested this on my local machine (Linux), on the tachiyomi-extensions GitHub runner, improved upon it and tested it again on the tachiyomi-extensions GitHub runner and it worked fine.

What I can't test is how it behaves on Windows, it should be fine but if someone could check out my https://github.com/E3FxGaming/tachiyomi-extensions/tree/FixMultisourceGen branch on Windows and run `./gradlew multisrc:generateExtensions` to see if it works, that would be great.

The `errorStream` of the sub-process gets redirected to the normal input that we receive from the sub-process, therefore we don't have to concern ourselves with the separate `errorStream`.