### PR TITLE
JapanRead: fix wrong chapter loaded

### DIFF
--- a/src/fr/japanread/build.gradle
+++ b/src/fr/japanread/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Japanread'
     pkgNameSuffix = 'fr.japanread'
     extClass = '.Japanread'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
There was a mismatch between chapter number and chapter id, resulting in wrong chapter loaded.

It's a recently added source but I'm surprised no one noticed.