### PR TITLE
Fix issue of MangasProject not building

### DIFF
--- a/multisrc/overrides/mangasproject/leitornet/src/LeitorNet.kt
+++ b/multisrc/overrides/mangasproject/leitornet/src/LeitorNet.kt
@@ -11,7 +11,6 @@ import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import java.util.concurrent.TimeUnit
-import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 
 class LeitorNet : MangasProject("Leitor.net", "https://leitor.net", "pt-br") {
 
@@ -20,13 +19,7 @@ class LeitorNet : MangasProject("Leitor.net", "https://leitor.net", "pt-br") {
     // became a different website, but they still use the same structure.
     // Existing mangas and other titles in the library still work.
     override val id: Long = 2225174659569980836
-    
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(RateLimitInterceptor(5, 1, TimeUnit.SECONDS))
-        .connectTimeout(1, TimeUnit.MINUTES)
-        .readTimeout(1, TimeUnit.MINUTES)
-        .writeTimeout(1, TimeUnit.MINUTES)
-        .build()
+   
 
     /**
      * Temporary fix to bypass Cloudflare.

--- a/multisrc/overrides/mangasproject/mangalivre/src/MangaLivre.kt
+++ b/multisrc/overrides/mangasproject/mangalivre/src/MangaLivre.kt
@@ -13,19 +13,12 @@ import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import java.util.concurrent.TimeUnit
-import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 
 class MangaLivre : MangasProject("Mangá Livre", "https://mangalivre.net", "pt-br") {
 
     // Hardcode the id because the language wasn't specific.
     override val id: Long = 4762777556012432014
     
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(RateLimitInterceptor(5, 1, TimeUnit.SECONDS))
-        .connectTimeout(1, TimeUnit.MINUTES)
-        .readTimeout(1, TimeUnit.MINUTES)
-        .writeTimeout(1, TimeUnit.MINUTES)
-        .build()
 
     override fun popularMangaRequest(page: Int): Request {
         val originalRequestUrl = super.popularMangaRequest(page).url().toString()

--- a/multisrc/overrides/mangasproject/toonei/src/Toonei.kt
+++ b/multisrc/overrides/mangasproject/toonei/src/Toonei.kt
@@ -9,17 +9,9 @@ import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import java.util.concurrent.TimeUnit
-import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 
 class Toonei : MangasProject("Toonei", "https://toonei.com", "pt-br") {
     
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(RateLimitInterceptor(5, 1, TimeUnit.SECONDS))
-        .connectTimeout(1, TimeUnit.MINUTES)
-        .readTimeout(1, TimeUnit.MINUTES)
-        .writeTimeout(1, TimeUnit.MINUTES)
-        .build()
-
     override fun getReaderToken(document: Document): String? {
         return document.select("script:containsData(window.PAGES_KEY)").firstOrNull()
             ?.data()


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
For some reason it refuse to import RateLimitInterceptor