### PR TITLE
handle interactive xkcd comics

### DIFF
--- a/src/en/xkcd/build.gradle
+++ b/src/en/xkcd/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'xkcd'
     pkgNameSuffix = 'en.xkcd'
     extClass = '.Xkcd'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/en/xkcd/src/eu/kanade/tachiyomi/extension/en/xkcd/Xkcd.kt
+++ b/src/en/xkcd/src/eu/kanade/tachiyomi/extension/en/xkcd/Xkcd.kt
@@ -59,12 +59,22 @@ class Xkcd : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val titleWords: Sequence<String>
         val altTextWords: Sequence<String>
+        val interactiveText = listOf(
+            "To experience the", "interactive version of this comic,",
+            "open it in WebView/browser."
+        )
+            .joinToString(separator = "%0A")
+            .replace(" ", "%20")
 
         // transforming filename from info.0.json isn't guaranteed to work, stick to html
         // if an HD image is available it'll be the srcset attribute
+        // if img tag is empty then it is an interactive comic viewable only in browser
         val image = document.select("div#comic img").let {
-            if (it.hasAttr("srcset")) it.attr("abs:srcset").substringBefore(" ")
-            else it.attr("abs:src")
+            when {
+                it == null || it.isEmpty() -> baseAltTextUrl + interactiveText + baseAltTextPostUrl
+                it.hasAttr("srcset") -> it.attr("abs:srcset").substringBefore(" ")
+                else -> it.attr("abs:src")
+            }
         }
 
         // create a text image for the alt text


### PR DESCRIPTION
closes #6370

Some xkcd comics tend to be interactive and can only be played in a regular browser
These cannot be loaded in the app and the reader loads indefinitely
Instead, we throw a text image with a message to open in browser

the div#comic img attribute will be null/empty in case of parsing interactive
comics and is then replaced with an image warning

uses [fakeimg.pl](https://fakeimg.pl/1500x2126/000000/ffffff/?text=To%20experience%20the%0Ainteractive%20version%20of%20this%20comic%0Aopen%20it%20in%20WebView/browser&font_size=42&font=museo) to generate image from text

Apk tested on 0.10.9 with examples from the linked issue 

| Screenshot |
|--|
| ![Screenshot_20210408-175049](https://user-images.githubusercontent.com/72807749/114025805-272ff180-9893-11eb-818a-ff85fc363e57.png) |

