### PR TITLE
Add initial support to more languages at MangaPlus

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '1.2'
 }
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -82,6 +82,14 @@ abstract class MangaPlus(
      * to properly filter the titles while their API doesn't get an update.
      */
     private val titlesToFix: Map<Int, Language> = mapOf(
+        // Thai
+        100079 to Language.THAI,
+        100080 to Language.THAI,
+        100082 to Language.THAI,
+        100120 to Language.THAI,
+        100121 to Language.THAI,
+
+        // Brazilian Portuguese
         100149 to Language.PORTUGUESE_BR,
         100150 to Language.PORTUGUESE_BR,
         100151 to Language.PORTUGUESE_BR
@@ -101,7 +109,8 @@ abstract class MangaPlus(
         if (result.success == null)
             throw Exception(result.error!!.langPopup.body)
 
-        titleList = fixWrongLanguages(result.success.titleRankingView!!.titles)
+        titleList = result.success.titleRankingView!!.titles
+            .fixWrongLanguages()
             .filter { it.language == langCode }
 
         val mangas = titleList!!.map {
@@ -133,14 +142,15 @@ abstract class MangaPlus(
         val popularResponse = client.newCall(popularMangaRequest(1)).execute().asProto()
 
         if (popularResponse.success != null) {
-            titleList = fixWrongLanguages(popularResponse.success.titleRankingView!!.titles)
+            titleList = popularResponse.success.titleRankingView!!.titles
+                .fixWrongLanguages()
                 .filter { it.language == langCode }
         }
 
         val mangas = result.success.webHomeView!!.groups
             .flatMap { it.titles }
             .mapNotNull { it.title }
-            .let { fixWrongLanguages(it) }
+            .fixWrongLanguages()
             .filter { it.language == langCode }
             .map {
                 SManga.create().apply {
@@ -173,7 +183,8 @@ abstract class MangaPlus(
         if (result.success == null)
             throw Exception(result.error!!.langPopup.body)
 
-        titleList = fixWrongLanguages(result.success.allTitlesView!!.titles)
+        titleList = result.success.allTitlesView!!.titles
+            .fixWrongLanguages()
             .filter { it.language == langCode }
 
         val mangas = titleList!!.map {
@@ -433,11 +444,9 @@ abstract class MangaPlus(
         return response
     }
 
-    private fun fixWrongLanguages(titles: List<Title>): List<Title> {
-        return titles.map { title ->
-            val correctLanguage = titlesToFix[title.titleId]
-            if (correctLanguage != null) title.copy(language = correctLanguage) else title
-        }
+    private fun List<Title>.fixWrongLanguages(): List<Title> = map { title ->
+        val correctLanguage = titlesToFix[title.titleId]
+        if (correctLanguage != null) title.copy(language = correctLanguage) else title
     }
 
     private val ErrorResult.langPopup: Popup

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -88,7 +88,13 @@ enum class Language(val id: Int) {
 
     @ProtoNumber(1)
     @SerializedName("1")
-    SPANISH(1)
+    SPANISH(1),
+
+    // Temporary add the Portuguese (Brazil) language,
+    // that is not present on the API yet.
+    // @ProtoNumber(2)
+    // @SerializedName("2")
+    PORTUGUESE_BR(2)
 }
 
 @Serializable
@@ -216,6 +222,7 @@ const val DECODE_SCRIPT: String =
     var Language = new Enum("Language")
         .add("ENGLISH", 0)
         .add("SPANISH", 1);
+    //     .add("PORTUGUESE_BR", 2);
 
     var UpdatedTitleGroup = new Type("UpdatedTitleGroup")
         .add(new Field("groupName", 1, "string"))

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -90,11 +90,14 @@ enum class Language(val id: Int) {
     @SerializedName("1")
     SPANISH(1),
 
-    // Temporary add the Portuguese (Brazil) language,
-    // that is not present on the API yet.
+    // Temporary add the languages that are not present on the API yet.
     // @ProtoNumber(2)
     // @SerializedName("2")
-    PORTUGUESE_BR(2)
+    THAI(2),
+
+    // @ProtoNumber(3)
+    // @SerializedName("3")
+    PORTUGUESE_BR(3)
 }
 
 @Serializable
@@ -222,7 +225,8 @@ const val DECODE_SCRIPT: String =
     var Language = new Enum("Language")
         .add("ENGLISH", 0)
         .add("SPANISH", 1);
-    //     .add("PORTUGUESE_BR", 2);
+    //     .add("THAI", 2)
+    //     .add("PORTUGUESE_BR", 3);
 
     var UpdatedTitleGroup = new Type("UpdatedTitleGroup")
         .add(new Field("groupName", 1, "string"))

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
@@ -4,13 +4,15 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 
 class MangaPlusFactory : SourceFactory {
-    override fun createSources(): List<Source> = getAllMangaPlus()
+    override fun createSources(): List<Source> = listOf(
+        MangaPlusEnglish(),
+        MangaPlusSpanish(),
+        MangaPlusPortuguese()
+    )
 }
 
 class MangaPlusEnglish : MangaPlus("en", "eng", Language.ENGLISH)
 class MangaPlusSpanish : MangaPlus("es", "esp", Language.SPANISH)
 
-fun getAllMangaPlus(): List<Source> = listOf(
-    MangaPlusEnglish(),
-    MangaPlusSpanish()
-)
+// The titles have the Portugal flag in the thumbnail, but the text of the translations is Brazilian.
+class MangaPlusPortuguese : MangaPlus("pt-BR", "eng", Language.PORTUGUESE_BR)

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
@@ -7,12 +7,14 @@ class MangaPlusFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
         MangaPlusEnglish(),
         MangaPlusSpanish(),
+        MangaPlusThai(),
         MangaPlusPortuguese()
     )
 }
 
 class MangaPlusEnglish : MangaPlus("en", "eng", Language.ENGLISH)
 class MangaPlusSpanish : MangaPlus("es", "esp", Language.SPANISH)
+class MangaPlusThai : MangaPlus("th", "eng", Language.THAI)
 
 // The titles have the Portugal flag in the thumbnail, but the text of the translations is Brazilian.
 class MangaPlusPortuguese : MangaPlus("pt-BR", "eng", Language.PORTUGUESE_BR)


### PR DESCRIPTION
MANGA Plus started supporting more languages recently, but their API doesn't return the information correctly.

This PR adds an initial support to basic filtering of the languages while their API doesn't get an update to handle this.

There are only 3 titles in Portuguese at the moment (One Piece, Spy x Family and Jujutsu Kaisen). These titles have the Portugal flag in the thumbnail, but the text of the translations are in Brazilian Portuguese.

I also added support to the titles in Thai language.

Closes #6503.