### PR TITLE
CatManga: Remember currentTimeMillis when a chapter is found for the first time

### DIFF
--- a/src/en/catmanga/build.gradle
+++ b/src/en/catmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'CatManga'
     pkgNameSuffix = "en.catmanga"
     extClass = '.CatManga'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
This prevents manga entries without any new chapter from getting bumped to the top of "Latest chapter" list when the library is updated.
