### PR TITLE
Update MH url (again)

### DIFF
--- a/src/pt/mangahost/build.gradle
+++ b/src/pt/mangahost/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangá Host'
     pkgNameSuffix = 'pt.mangahost'
     extClass = '.MangaHost'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
+++ b/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
@@ -31,7 +31,7 @@ class MangaHost : ParsedHttpSource() {
 
     override val name = "Mangá Host"
 
-    override val baseUrl = "https://mangahostz.com"
+    override val baseUrl = "https://mangahosted.com"
 
     override val lang = "pt-BR"
 
@@ -56,7 +56,7 @@ class MangaHost : ParsedHttpSource() {
 
             title = element.attr("title").withoutLanguage()
             thumbnail_url = thumbnailEl.attr(thumbnailAttr).toLargeUrl()
-            setUrlWithoutDomain(element.attr("href").substringBeforeLast("-mh"))
+            setUrlWithoutDomain(element.attr("href"))
         }
 
     override fun popularMangaRequest(page: Int): Request {
@@ -191,7 +191,7 @@ class MangaHost : ParsedHttpSource() {
     override fun imageRequest(page: Page): Request {
         val newHeaders = headersBuilder()
             .set("Accept", ACCEPT_IMAGE)
-            .set("Referer", baseUrl)
+            .set("Referer", "$baseUrl/")
             .build()
 
         return GET(page.imageUrl!!, newHeaders)


### PR DESCRIPTION
I also updated the URL of the titles to avoid (for a while) the HTTP 403.

Entries in the library should still work, but users can migrate from MH to MH to update the URLs if they want too.
