### PR TITLE
Make rate limiting apply to all requests in MH

### DIFF
--- a/src/pt/mangahost/build.gradle
+++ b/src/pt/mangahost/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangá Host'
     pkgNameSuffix = 'pt.mangahost'
     extClass = '.MangaHost'
-    extVersionCode = 22
+    extVersionCode = 23
     libVersion = '1.2'
 }
 

--- a/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
+++ b/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
@@ -38,10 +38,9 @@ class MangaHost : ParsedHttpSource() {
     override val supportsLatest = true
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(::rateLimitIntercept)
+        .addInterceptor(RateLimitInterceptor(1, 3, TimeUnit.SECONDS))
+        .addInterceptor(::blockMessageIntercept)
         .build()
-
-    private val rateLimitInterceptor = RateLimitInterceptor(1, 3, TimeUnit.SECONDS)
 
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("Accept", ACCEPT)
@@ -197,12 +196,15 @@ class MangaHost : ParsedHttpSource() {
         return GET(page.imageUrl!!, newHeaders)
     }
 
-    private fun rateLimitIntercept(chain: Interceptor.Chain): Response {
-        return if (chain.request().url().toString().contains(CDN_REGEX)) {
-            chain.proceed(chain.request())
-        } else {
-            rateLimitInterceptor.intercept(chain)
+    private fun blockMessageIntercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+
+        if (!response.isSuccessful && response.code() == 403) {
+            response.close()
+            throw Exception(BLOCK_MESSAGE)
         }
+
+        return response
     }
 
     private fun Call.asObservableIgnoreCode(code: Int): Observable<Response> {
@@ -245,6 +247,8 @@ class MangaHost : ParsedHttpSource() {
         private val LANG_REGEX = "( )?\\((PT-)?BR\\)".toRegex()
         private val IMAGE_REGEX = "_(small|medium|xmedium)\\.".toRegex()
         private val CDN_REGEX = "/mangas_files/.*\\.jpg".toRegex()
+
+        private const val BLOCK_MESSAGE = "O site está bloqueando o Tachiyomi. Tente novamente mais tarde ou migre para outra fonte."
 
         private val DATE_FORMAT by lazy {
             SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH)

--- a/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
+++ b/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
@@ -248,7 +248,7 @@ class MangaHost : ParsedHttpSource() {
         private val IMAGE_REGEX = "_(small|medium|xmedium)\\.".toRegex()
         private val CDN_REGEX = "/mangas_files/.*\\.jpg".toRegex()
 
-        private const val BLOCK_MESSAGE = "O site está bloqueando o Tachiyomi. Tente novamente mais tarde ou migre para outra fonte."
+        private const val BLOCK_MESSAGE = "O site está bloqueando o Tachiyomi. Migre para outra fonte caso o problema persistir."
 
         private val DATE_FORMAT by lazy {
             SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH)


### PR DESCRIPTION
I also changed the HTTP 403 error to be more explicit about the blocking.

As I said (in Portuguese) in #6537, let's see if the more severe rate limiting unloads the server a while.

If it's not the case, I will then submit a new PR to end this cat and mouse game.

Closes #6537.
