### PR TITLE
Update 'UM' selectors (again) and add a blocking message

### DIFF
--- a/src/pt/unionmangas/build.gradle
+++ b/src/pt/unionmangas/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Union Mangás'
     pkgNameSuffix = 'pt.unionmangas'
     extClass = '.UnionMangas'
-    extVersionCode = 21
+    extVersionCode = 22
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
It seems I was right on #6623, and it's really a cat and mouse game now.

If you are reading this and use the extension, it's recommended to migrate to another source.

I updated the selectors one last time, and added a message about the blocking that will show when they change things.

When this happens, I will leave the extension with the blocking message for a while and then submit a new PR to remove it, since it's not worthy anymore to keep maintaining. The users can migrate to better sources.