### PR TITLE
Update selectors and show a blocking message if no results found

### DIFF
--- a/src/pt/mangahost/build.gradle
+++ b/src/pt/mangahost/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangá Host'
     pkgNameSuffix = 'pt.mangahost'
     extClass = '.MangaHost'
-    extVersionCode = 23
+    extVersionCode = 24
     libVersion = '1.2'
 }
 

--- a/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
+++ b/src/pt/mangahost/src/eu/kanade/tachiyomi/extension/pt/mangahost/MangaHost.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservable
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
@@ -31,7 +32,7 @@ class MangaHost : ParsedHttpSource() {
 
     override val name = "Mangá Host"
 
-    override val baseUrl = "https://mangahosted.com"
+    override val baseUrl = "https://mangahostz.com"
 
     override val lang = "pt-BR"
 
@@ -48,15 +49,14 @@ class MangaHost : ParsedHttpSource() {
         .add("Referer", baseUrl)
         .add("User-Agent", USER_AGENT)
 
-    private fun genericMangaFromElement(element: Element): SManga =
-        SManga.create().apply {
-            val thumbnailEl = element.select("img")
-            val thumbnailAttr = if (thumbnailEl.hasAttr("data-path")) "data-path" else "src"
+    private fun genericMangaFromElement(element: Element): SManga = SManga.create().apply {
+        val thumbnailEl = element.select("img")
+        val thumbnailAttr = if (thumbnailEl.hasAttr("data-path")) "data-path" else "src"
 
-            title = element.attr("title").withoutLanguage()
-            thumbnail_url = thumbnailEl.attr(thumbnailAttr).toLargeUrl()
-            setUrlWithoutDomain(element.attr("href"))
-        }
+        title = element.attr("title").withoutLanguage()
+        thumbnail_url = thumbnailEl.attr(thumbnailAttr).toLargeUrl()
+        setUrlWithoutDomain(element.attr("href"))
+    }
 
     override fun popularMangaRequest(page: Int): Request {
         val listPath = if (page == 1) "" else "/mais-visualizados/page/${page - 1}"
@@ -66,6 +66,16 @@ class MangaHost : ParsedHttpSource() {
 
         val pageStr = if (page != 1) "/page/$page" else ""
         return GET("$baseUrl/mangas/mais-visualizados$pageStr", newHeaders)
+    }
+
+    override fun popularMangaParse(response: Response): MangasPage {
+        val results = super.popularMangaParse(response)
+
+        if (results.mangas.isEmpty()) {
+            throw Exception(BLOCK_MESSAGE)
+        }
+
+        return results
     }
 
     override fun popularMangaSelector(): String = "div#dados div.manga-block div.manga-block-left a"
@@ -84,7 +94,17 @@ class MangaHost : ParsedHttpSource() {
         return GET("$baseUrl/lancamentos$pageStr", newHeaders)
     }
 
-    override fun latestUpdatesSelector() = "div#dados div.line-lancamentos div.column-img a"
+    override fun latestUpdatesParse(response: Response): MangasPage {
+        val results = super.latestUpdatesParse(response)
+
+        if (results.mangas.isEmpty()) {
+            throw Exception(BLOCK_MESSAGE)
+        }
+
+        return results
+    }
+
+    override fun latestUpdatesSelector() = "div#dados div.w-row div.column-img a"
 
     override fun latestUpdatesFromElement(element: Element): SManga = genericMangaFromElement(element)
 
@@ -117,6 +137,7 @@ class MangaHost : ParsedHttpSource() {
 
     override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
         val infoElement = document.select("div.box-content div.w-row div.w-col:eq(1) article")
+            .firstOrNull() ?: throw Exception(BLOCK_MESSAGE)
 
         author = infoElement.select("div.text li div:contains(Autor:)").textWithoutLabel()
         artist = infoElement.select("div.text li div:contains(Arte:)").textWithoutLabel()
@@ -142,8 +163,18 @@ class MangaHost : ParsedHttpSource() {
         }
     }
 
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = super.chapterListParse(response)
+
+        if (chapters.isEmpty()) {
+            throw Exception(BLOCK_MESSAGE)
+        }
+
+        return chapters
+    }
+
     override fun chapterListSelector(): String =
-        "article.article > section.clearfix div.chapters div.cap div.card.pop"
+        "article section.clearfix div.chapters div.cap div.card.pop"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         name = element.select("div.pop-title").text().withoutLanguage()
@@ -199,7 +230,7 @@ class MangaHost : ParsedHttpSource() {
     private fun blockMessageIntercept(chain: Interceptor.Chain): Response {
         val response = chain.proceed(chain.request())
 
-        if (!response.isSuccessful && response.code() == 403) {
+        if (response.code() == 403 || response.code() == 1020) {
             response.close()
             throw Exception(BLOCK_MESSAGE)
         }
@@ -224,9 +255,9 @@ class MangaHost : ParsedHttpSource() {
         }
     }
 
-    private fun String.toStatus() = when {
-        contains("Ativo") -> SManga.ONGOING
-        contains("Completo") -> SManga.COMPLETED
+    private fun String.toStatus() = when (this) {
+        "Ativo" -> SManga.ONGOING
+        "Completo" -> SManga.COMPLETED
         else -> SManga.UNKNOWN
     }
 
@@ -246,9 +277,9 @@ class MangaHost : ParsedHttpSource() {
 
         private val LANG_REGEX = "( )?\\((PT-)?BR\\)".toRegex()
         private val IMAGE_REGEX = "_(small|medium|xmedium)\\.".toRegex()
-        private val CDN_REGEX = "/mangas_files/.*\\.jpg".toRegex()
 
-        private const val BLOCK_MESSAGE = "O site está bloqueando o Tachiyomi. Migre para outra fonte caso o problema persistir."
+        private const val BLOCK_MESSAGE = "O site está bloqueando o Tachiyomi. " +
+            "Migre para outra fonte caso o problema persistir."
 
         private val DATE_FORMAT by lazy {
             SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH)


### PR DESCRIPTION
The source seems to be changing constantly the classes to break the extension too.

I updated the selectors to the most recent ones and added a blocking message that will show when they change them again.

Users should have migrated from this source already, but unfortunately some still use the extension.

It's not worthy to keep maintaining this extension anymore.