### PR TITLE
Changed url for mangapark extension

### DIFF
--- a/src/en/mangapark/build.gradle
+++ b/src/en/mangapark/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaPark'
     pkgNameSuffix = 'en.mangapark'
     extClass = '.MangaPark'
-    extVersionCode = 18
+    extVersionCode = 19
     libVersion = '1.2'
 }
 

--- a/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
+++ b/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
@@ -35,7 +35,7 @@ class MangaPark : ConfigurableSource, ParsedHttpSource() {
 
     override val supportsLatest = true
     override val name = "MangaPark"
-    override val baseUrl = "https://mangapark.net"
+    override val baseUrl = "https://v2.mangapark.net"
 
     private val nextPageSelector = ".paging:not(.order) > li:last-child > a"
 


### PR DESCRIPTION
Site updated, they still have a copy of legacy interface on a secondary url, this is a stand in for a redoing the scraper, only a temporary measure. 



Closes #6721

