### PR TITLE
[Komga] fix restoring backup & tags in filter panel

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 1.2.23
 
+Minimum Komga version required: `0.87.4`
+
+### Fix
+
+* only show series tags in the filter panel
+* set URL properly on series and read lists, so restoring from a backup can work properly
+
+
+## 1.2.23
+
 Minimum Komga version required: `0.75.0`
 
 ### Features

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 23
+    extVersionCode = 24
     libVersion = '1.2'
 }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -164,7 +164,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
         processSeriesPage(response)
 
     override fun mangaDetailsRequest(manga: SManga): Request =
-        GET(baseUrl + manga.url, headers)
+        GET(manga.url, headers)
 
     override fun mangaDetailsParse(response: Response): SManga =
         if (response.fromReadList()) {
@@ -176,7 +176,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
         }
 
     override fun chapterListRequest(manga: SManga): Request =
-        GET("$baseUrl${manga.url}/books?unpaged=true&media_status=READY", headers)
+        GET("${manga.url}/books?unpaged=true&media_status=READY", headers)
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val page = gson.fromJson<PageWrapperDto<BookDto>>(response.body()?.charStream()!!).content
@@ -227,8 +227,8 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
     private fun SeriesDto.toSManga(): SManga =
         SManga.create().apply {
             title = metadata.title
-            url = "/api/v1/series/$id"
-            thumbnail_url = "$baseUrl/api/v1/series/$id/thumbnail"
+            url = "$baseUrl/api/v1/series/$id"
+            thumbnail_url = "$url/thumbnail"
             status = when (metadata.status) {
                 "ONGOING" -> SManga.ONGOING
                 "ENDED" -> SManga.COMPLETED
@@ -245,8 +245,8 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
     private fun ReadListDto.toSManga(): SManga =
         SManga.create().apply {
             title = name
-            url = "/api/v1/readlists/$id"
-            thumbnail_url = "$baseUrl/api/v1/readlists/$id/thumbnail"
+            url = "$baseUrl/api/v1/readlists/$id"
+            thumbnail_url = "$url/thumbnail"
             status = SManga.UNKNOWN
         }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -487,7 +487,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
                 )
 
             Single.fromCallable {
-                client.newCall(GET("$baseUrl/api/v1/tags", headers)).execute()
+                client.newCall(GET("$baseUrl/api/v1/tags/series", headers)).execute()
             }
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
The URL was not fully set in the `SManga` object, it did not contain the base URL. This was meant to handle URL change in the extension settings, but probably wouldn't have worked given Tachiyomi stores SManga locally. Because of that, restoring from a backup would generate some errors because URL would be missing `http` or `https`. This will not help people with existing library though, they would need to edit the backup file manually to fix it.

This also uses the newly introduced API endpoint to only get Series tags for filtering. Before it was showing also book tags, but filtering on those would not yield any results.