### PR TITLE
Fix Tapas and Japanread

### DIFF
--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Tapas'
     pkgNameSuffix = 'en.tapastic'
     extClass = '.Tapastic'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '1.2'
 }
 

--- a/src/fr/japanread/build.gradle
+++ b/src/fr/japanread/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Japanread'
     pkgNameSuffix = 'fr.japanread'
     extClass = '.Japanread'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
I fixed a few things in `Japanread` (missing chapters when multiple pages, wrong `popularManga` url).

I also added a preference in settings for `Tapas` to show the lock for locked chapters even after login (I think it's quite useful to know whether it's already unlock or not). And I changed the default header to display the mobile version in WebView instead of the desktop one.
