### PR TITLE
Fix wrong package in two sources at Madara

### DIFF
--- a/multisrc/overrides/madara/mangamitsu/src/MangaMitsu.kt
+++ b/multisrc/overrides/madara/mangamitsu/src/MangaMitsu.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.extension.es.mangamitsu
+package eu.kanade.tachiyomi.extension.en.mangamitsu
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.annotations.Nsfw

--- a/multisrc/overrides/madara/mangayami/src/MangaYami.kt
+++ b/multisrc/overrides/madara/mangayami/src/MangaYami.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.extension.es.mangayami
+package eu.kanade.tachiyomi.extension.en.mangayami
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -264,9 +264,9 @@ class MadaraGenerator : ThemeSourceGenerator {
             SingleLang("Pornwha", "https://pornwha.com", "en", isNsfw = true),
             SingleLang("Wakamics", "https://wakamics.net", "en"),
             SingleLang("Traducciones Amistosas", "https://nartag.com", "es"),
-            SingleLang("MangaYami", "https://www.mangayami.club", "en"),
+            SingleLang("MangaYami", "https://www.mangayami.club", "en", overrideVersionCode = 1),
             SingleLang("Manga Fenix", "https://manga-fenix.com", "es"),
-            SingleLang("Manga Mitsu", "https://mangamitsu.com", "en", isNsfw = true),
+            SingleLang("Manga Mitsu", "https://mangamitsu.com", "en", isNsfw = true, overrideVersionCode = 1),
     )
 
     companion object {


### PR DESCRIPTION
PR #6802 wrongly put two English sources in the Spanish package in the overrides.

Will probably close #6814.