### PR TITLE
Fix wpmangareader filtering + Dynamically Fetch Genres

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
@@ -9,7 +9,7 @@ class WPMangaReaderGenerator : ThemeSourceGenerator {
 
     override val themeClass = "WPMangaReader"
 
-    override val baseVersionCode: Int = 4
+    override val baseVersionCode: Int = 5
 
     override val sources = listOf(
 


### PR DESCRIPTION
Per [wordpress mangareader's changelog](https://themesia.com/mangareader-wordpress-theme/#changelog), it seems like search had been changed a bit after the filters were originally implemented in this extension. So it has been broken for a few months.

This pull request updates the filtering and also adds in some logic to dynamically fetch genres (which differ from site to site)

Aside:

It'd be dope if the Sources had a bit more support for dynamic filters -> tachiyomi eagerly fetches filters from sources, and the only way to get the view to update is seemingly to get the user to hit reset

Either delaying the initialization of filters until after an initial request (popular/latest) is made, or providing a callback that allows the source to force a redraw would go a long way to make this possible.
