### PR TITLE
Describe how to use debugger + Clarify Run Configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,7 +354,7 @@ with open(f"{package}/src/{source}.kt", "w") as f:
 
 ## Running
 
-To aid in local development, you can use the following run configuration to launch an extension:
+To make local development more convenient, you can use the following run configuration to launch Tachiyomi directly at the Browse panel:
 
 ![](https://i.imgur.com/STy0UFY.png)
 
@@ -372,7 +372,21 @@ And for a release build of Tachiyomi:
 
 ## Debugging
 
-Directly debugging your extension (i.e stepping through the extension code) is not possible due to the way that extension code is loaded into the app. However, logs printed from extensions (via [`Logcat`](https://developer.android.com/studio/debug/am-logcat)) do work.
+### Android Debugger
+
+You can leverage the Android Debugger to step through your extension while debugging.
+
+You *cannot* simply use Android Studio's `Debug 'module.name'` -> this will most likely result in an error while launching.
+
+Instead, once you've built and installed your extension on the target device, use `Attach Debugger to Android Process` to start debugging Tachiyomi.
+
+![](https://i.imgur.com/muhXyfu.png)
+
+
+### Logs
+
+You can also elect to simply rely on logs printed from your extension, which
+show up in the [`Logcat`](https://developer.android.com/studio/debug/am-logcat) panel of Android Studio
 
 
 ## Building


### PR DESCRIPTION
@hapylestat noticed in #3669 that tachiyomi extensions can be debugged with the debugger, by using `Attach debugger to Android Process` to attach to the running Tachiyomi instance.

The requirements to do so are looser than described in the issue; Tachiyomi doesn't need to be launched with a specific run configuration for this to work. 


I was able to validate that this with the Android emulator, but have yet to do so on a physical device.

I edited CONTRIBUTING.md to reflect this.

(I also clarified what the provided run configuration in the `Running` section actually does)


Closes #3669