### PR TITLE
Facilitate Deeplinking for multisrc extensions

### DIFF
--- a/multisrc/overrides/wpmangareader/default/AndroidManifest.xml
+++ b/multisrc/overrides/wpmangareader/default/AndroidManifest.xml
@@ -17,6 +17,16 @@
                     android:pathPattern="/.*/..*"
                     android:scheme="${SOURCESCHEME}" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="${SOURCEHOST}"
+                    android:pathPattern="/..*"
+                    android:scheme="${SOURCESCHEME}" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/multisrc/overrides/wpmangareader/default/AndroidManifest.xml
+++ b/multisrc/overrides/wpmangareader/default/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.extension">
+
+    <application>
+        <activity
+            android:name="eu.kanade.tachiyomi.multisrc.wpmangareader.WPMangaReaderUrlActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="${SOURCEHOST}"
+                    android:pathPattern="/.*/..*"
+                    android:scheme="${SOURCESCHEME}" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/multisrc/overrides/wpmangareader/gsnation/src/GSNation.kt
+++ b/multisrc/overrides/wpmangareader/gsnation/src/GSNation.kt
@@ -36,6 +36,7 @@ class GSNation : WPMangaReader("GS Nation", "http://gs-nation.fr", "fr", dateFor
 
         thumbnail_url = document.select("div.thumb img").attr("abs:src")
         description = document.select(".entry-content[itemprop=description]").joinToString("\n") { it.text() }
+        title = document.selectFirst("h1.entry-title").text()
 
         // add series type(manga/manhwa/manhua/other) thinggy to genre
         document.select(seriesTypeSelector).firstOrNull()?.ownText()?.let {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
@@ -9,7 +9,7 @@ class WPMangaReaderGenerator : ThemeSourceGenerator {
 
     override val themeClass = "WPMangaReader"
 
-    override val baseVersionCode: Int = 5
+    override val baseVersionCode: Int = 6
 
     override val sources = listOf(
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderUrlActivity.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderUrlActivity.kt
@@ -1,0 +1,36 @@
+package eu.kanade.tachiyomi.multisrc.wpmangareader
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import eu.kanade.tachiyomi.multisrc.wpmangareader.WPMangaReader
+import kotlin.system.exitProcess
+
+class WPMangaReaderUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+
+        if (pathSegments != null && pathSegments.size >= 2) {
+
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query","${WPMangaReader.URL_SEARCH_PREFIX}${intent?.data?.toString()}")
+                putExtra("filter", packageName)
+            }
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("WPMangaReaderUrl", e.toString())
+            }
+        } else {
+            Log.e("WPMangaReaderUrl", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderUrlActivity.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderUrlActivity.kt
@@ -14,7 +14,7 @@ class WPMangaReaderUrlActivity : Activity() {
         super.onCreate(savedInstanceState)
         val pathSegments = intent?.data?.pathSegments
 
-        if (pathSegments != null && pathSegments.size >= 2) {
+        if (pathSegments != null && pathSegments.size >= 1) {
 
             val mainIntent = Intent().apply {
                 action = "eu.kanade.tachiyomi.SEARCH"

--- a/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
+++ b/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
@@ -57,9 +57,7 @@ interface ThemeSourceGenerator {
             val additionalGradleOverrideText = File(additionalGradleOverridePath).readTextOrEmptyString()
             val placeholders = mapOf(
                 "SOURCEHOST" to source.baseUrl.toHttpUrlOrNull()?.host,
-                "SOURCESCHEME" to source.baseUrl.toHttpUrlOrNull()?.scheme,
-                "SOURCECLASSNAME" to source.className,
-                "SOURCEPKGNAME" to source.pkgName
+                "SOURCESCHEME" to source.baseUrl.toHttpUrlOrNull()?.scheme
             ).filter { it.value != null }
             gradle.writeText("""
                 // THIS FILE IS AUTO-GENERATED; DO NOT EDIT

--- a/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
+++ b/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
@@ -55,6 +55,12 @@ interface ThemeSourceGenerator {
 
             val defaultAdditionalGradleText = File(defaultAdditionalGradlePath).readTextOrEmptyString()
             val additionalGradleOverrideText = File(additionalGradleOverridePath).readTextOrEmptyString()
+            val placeholders = mapOf(
+                "SOURCEHOST" to source.baseUrl.toHttpUrlOrNull()?.host,
+                "SOURCESCHEME" to source.baseUrl.toHttpUrlOrNull()?.scheme,
+                "SOURCECLASSNAME" to source.className,
+                "SOURCEPKGNAME" to source.pkgName
+            ).filter { it.value != null }
             gradle.writeText("""
                 // THIS FILE IS AUTO-GENERATED; DO NOT EDIT
                 apply plugin: 'com.android.application'
@@ -76,10 +82,7 @@ interface ThemeSourceGenerator {
                 android {
                     defaultConfig {
                         manifestPlaceholders += [
-                            SOURCEHOST: "${source.baseUrl.toHttpUrlOrNull()!!.host}",
-                            SOURCESCHEME: "${source.baseUrl.toHttpUrlOrNull()!!.scheme}",
-                            SOURCECLASSNAME: "${source.className}",
-                            SOURCEPKGNAME: "${source.pkgName}"
+${placeholders.map { "${" ".repeat(28)}${it.key}: \"${it.value}\""}.joinToString(",\n")}
                         ]
                     }
                 }


### PR DESCRIPTION
A large portion of tachiyomi extensions are generated from templates, and the only way to currently set a non-default AndroidManifest.xml is to write an override for every single generated extension.

This pull request:

* Adds support for a default [AndroidManifest.xml](https://github.com/h-hyuuga/tachiyomi-extensions/blob/27a12e81addfa281678ca80157b39293cd2fbc59/multisrc/src/main/java/generator/ThemeSourceGenerator.kt#L94) for all extensions generated from a theme source
* [Modifies the default generated `build.gradle` to include useful manifestPlaceholders for building intents](https://github.com/h-hyuuga/tachiyomi-extensions/blob/27a12e81addfa281678ca80157b39293cd2fbc59/multisrc/src/main/java/generator/ThemeSourceGenerator.kt#L76)
* Implements deeplinking in `wpmangareader` as an example.

If anyone has any comments or notices anything  stupid I'm doing  in regard to the changes to `ThemeSourceGenerator.kt`, feel free to let me know.
