### PR TITLE
Flame Scans: http -> https

### DIFF
--- a/multisrc/overrides/wpmangareader/flamescans/src/FlameScans.kt
+++ b/multisrc/overrides/wpmangareader/flamescans/src/FlameScans.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.multisrc.wpmangareader.WPMangaReader
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
-class FlameScans : WPMangaReader("Flame Scans", "http://flamescans.org", "en", "/series") {
+class FlameScans : WPMangaReader("Flame Scans", "https://flamescans.org", "en", "/series") {
     private val rateLimitInterceptor = RateLimitInterceptor(4)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
@@ -20,7 +20,7 @@ class WPMangaReaderGenerator : ThemeSourceGenerator {
             SingleLang("Davey Scans", "https://daveyscans.com/", "id"),
             SingleLang("TurkToon", "https://turktoon.com", "tr"),
             SingleLang("Gecenin Lordu", "https://geceninlordu.com/", "tr", overrideVersionCode = 1),
-            SingleLang("Flame Scans", "http://flamescans.org", "en", overrideVersionCode = 1),
+            SingleLang("Flame Scans", "https://flamescans.org", "en", overrideVersionCode = 2),
             SingleLang("A Pair of 2+", "https://pairof2.com", "en", className = "APairOf2"),
             SingleLang("PMScans", "https://reader.pmscans.com", "en"),
             SingleLang("Skull Scans", "https://www.skullscans.com", "en"),


### PR DESCRIPTION
This pull request corrects flamescan.org's scheme to `https`. 