### PR TITLE
Add a warning when the manga URL changes in NS

### DIFF
--- a/multisrc/overrides/madara/neoxscanlator/src/NeoxScanlator.kt
+++ b/multisrc/overrides/madara/neoxscanlator/src/NeoxScanlator.kt
@@ -2,9 +2,15 @@ package eu.kanade.tachiyomi.extension.pt.neoxscanlator
 
 import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.asObservable
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Headers
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import rx.Observable
+import java.lang.Exception
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -25,6 +31,43 @@ class NeoxScanlator : Madara(
         .add("Referer", baseUrl)
         .add("Origin", baseUrl)
 
+    // Filter the novels in pure text format.
+    override fun popularMangaSelector() = "div.page-item-detail.manga"
+
+    override fun searchMangaParse(response: Response): MangasPage {
+        val mangaPage = super.searchMangaParse(response)
+        val filteredResult = mangaPage.mangas.filter { it.title.contains(NOVEL_REGEX).not() }
+
+        return MangasPage(filteredResult, mangaPage.hasNextPage)
+    }
+
+    // Sometimes the site changes the manga URL. This override will
+    // add an error instead of the HTTP 404 to inform the user to
+    // migrate from Neox to Neox to update the URL.
+    override fun fetchMangaDetails(manga: SManga): Observable<SManga> {
+        return client.newCall(mangaDetailsRequest(manga))
+            .asObservable()
+            .doOnNext { response ->
+                if (!response.isSuccessful) {
+                    response.close()
+                    throw Exception(if (response.code == 404) MIGRATION_MESSAGE else "HTTP error ${response.code}")
+                }
+            }
+            .map { response ->
+                mangaDetailsParse(response).apply { initialized = true }
+            }
+    }
+
+    override val altNameSelector = ".post-content_item:contains(Alternativo) .summary-content"
+    override val altName = "Nome alternativo: "
+
     // Only status and order by filter work.
     override fun getFilterList(): FilterList = FilterList(super.getFilterList().slice(3..4))
+
+    companion object {
+        private const val MIGRATION_MESSAGE = "O URL deste mangá mudou. " +
+            "Faça a migração do Neox para o Neox para atualizar a URL."
+
+        private val NOVEL_REGEX = "novel|livro".toRegex(RegexOption.IGNORE_CASE)
+    }
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -392,12 +392,13 @@ abstract class Madara(
     open val seriesTypeSelector = ".post-content_item:contains(Type) .summary-content"
     open val altNameSelector = ".post-content_item:contains(Alt) .summary-content"
     open val altName = "Alternative Name" + ": "
+    open val updatingRegex = "Updating|Atualizando".toRegex(RegexOption.IGNORE_CASE)
 
     private fun String.notUpdating(): Boolean {
-        return this.contains("Updating", true).not()
+        return this.contains(updatingRegex).not()
     }
 
-    protected open fun imageFromElement(element: Element): String? {
+    protected fun imageFromElement(element: Element): String? {
         return when {
             element.hasAttr("data-src") -> element.attr("abs:data-src")
             element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -398,7 +398,7 @@ abstract class Madara(
         return this.contains(updatingRegex).not()
     }
 
-    protected fun imageFromElement(element: Element): String? {
+    protected open fun imageFromElement(element: Element): String? {
         return when {
             element.hasAttr("data-src") -> element.attr("abs:data-src")
             element.hasAttr("data-lazy-src") -> element.attr("abs:data-lazy-src")

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -183,7 +183,7 @@ class MadaraGenerator : ThemeSourceGenerator {
             SingleLang("Nazarick Scans", "https://nazarickscans.com", "en"),
             SingleLang("NeatManga", "https://neatmanga.com", "en"),
             SingleLang("NekoScan", "https://nekoscan.com", "en", overrideVersionCode = 1),
-            SingleLang("Neox Scanlator", "https://neoxscans.net", "pt-BR", overrideVersionCode = 2),
+            SingleLang("Neox Scanlator", "https://neoxscans.net", "pt-BR", overrideVersionCode = 3),
             SingleLang("Night Comic", "https://www.nightcomic.com", "en"),
             SingleLang("Niji Translations", "https://niji-translations.com", "ar"),
             SingleLang("Ninjavi", "https://ninjavi.com", "ar", overrideVersionCode = 1),


### PR DESCRIPTION
Reported by some users that sometimes the source changes the slug of the manga (I don't know if this is a measure to prevent 3rd party apps from accessing their content). Now, when this happens again, there will be a warning to inform the user to migrate the manga from the source to the same source to update the URL.

I also filtered the novels in pure text format, that the app does not support.