### PR TITLE
Fix Witchy from HiveworksComic

### DIFF
--- a/src/en/hiveworks/build.gradle
+++ b/src/en/hiveworks/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Hiveworks Comics'
     pkgNameSuffix = 'en.hiveworks'
     extClass = '.Hiveworks'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Witchy used to be broken on hiveworks, due to having a custom page for /comic/archive that uses a bunch of links instead of an `<option>` for each page (see https://www.witchycomic.com/comic/archive vs https://www.sleeplessdomain.com/comic/archive : the select control is missing).