### PR TITLE
Use correct field name for MD@H report endpoint

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 112
+    extVersionCode = 113
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexInterceptors.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexInterceptors.kt
@@ -50,7 +50,7 @@ class MdAtHomeReportInterceptor(
                         "success" to response.isSuccessful,
                         "bytes" to response.peekBody(Long.MAX_VALUE).bytes().size,
                         "duration" to response.receivedResponseAtMillis - response.sentRequestAtMillis,
-                        "cache" to cachedImage,
+                        "cached" to cachedImage,
                     )
                 )
 


### PR DESCRIPTION
Today, all report requests are denied by MD@H backend since the field doesn't match the required schema:

```Go
type reportRequest struct {
    URL      string  `json:"url"`
    Success  bool    `json:"success"`
    Bytes    int     `json:"bytes"`
    Duration float64 `json:"duration"` // milliseconds, can have decimal places
    Cached   bool    `json:"cached"`
}
```