### PR TITLE
FMReader Fixes Pt.2: The Encryption Strikes Back

### DIFF
--- a/multisrc/overrides/fmreader/heroscan/additional.gradle.kts
+++ b/multisrc/overrides/fmreader/heroscan/additional.gradle.kts
@@ -1,0 +1,4 @@
+
+dependencies {
+    implementation project(':lib-ratelimit')
+}

--- a/multisrc/overrides/fmreader/heroscan/src/HeroScan.kt
+++ b/multisrc/overrides/fmreader/heroscan/src/HeroScan.kt
@@ -1,11 +1,13 @@
 package eu.kanade.tachiyomi.extension.en.heroscan
 
+import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
 import eu.kanade.tachiyomi.source.model.SChapter
 import okhttp3.OkHttpClient
 
 class HeroScan : FMReader("HeroScan", "https://heroscan.com", "en") {
     override val client: OkHttpClient = super.client.newBuilder()
+            .addInterceptor(RateLimitInterceptor(1, period=1))
             .addInterceptor { chain ->
                 val originalRequest = chain.request()
                 chain.proceed(originalRequest).let { response ->

--- a/multisrc/overrides/fmreader/heroscan/src/HeroScan.kt
+++ b/multisrc/overrides/fmreader/heroscan/src/HeroScan.kt
@@ -7,7 +7,7 @@ import okhttp3.OkHttpClient
 
 class HeroScan : FMReader("HeroScan", "https://heroscan.com", "en") {
     override val client: OkHttpClient = super.client.newBuilder()
-            .addInterceptor(RateLimitInterceptor(1, period=1))
+            .addInterceptor(RateLimitInterceptor(1))
             .addInterceptor { chain ->
                 val originalRequest = chain.request()
                 chain.proceed(originalRequest).let { response ->

--- a/multisrc/overrides/fmreader/manhuascan/additional.gradle.kts
+++ b/multisrc/overrides/fmreader/manhuascan/additional.gradle.kts
@@ -1,0 +1,4 @@
+
+dependencies {
+    implementation project(':lib-ratelimit')
+}

--- a/multisrc/overrides/fmreader/manhuascan/src/ManhuaScan.kt
+++ b/multisrc/overrides/fmreader/manhuascan/src/ManhuaScan.kt
@@ -1,12 +1,15 @@
 package eu.kanade.tachiyomi.extension.en.manhuascan
 
+import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
 import eu.kanade.tachiyomi.source.model.SChapter
-
 import eu.kanade.tachiyomi.annotations.Nsfw
-
+import okhttp3.OkHttpClient
 
 @Nsfw
 class ManhuaScan : FMReader("ManhuaScan", "https://manhuascan.com", "en") {
+    override val client: OkHttpClient = super.client.newBuilder()
+        .addInterceptor(RateLimitInterceptor(1, period=1))
+        .build()
     override fun fetchPageList(chapter: SChapter) = fetchPageListEncrypted(chapter)
 }

--- a/multisrc/overrides/fmreader/manhuascan/src/ManhuaScan.kt
+++ b/multisrc/overrides/fmreader/manhuascan/src/ManhuaScan.kt
@@ -9,7 +9,7 @@ import okhttp3.OkHttpClient
 @Nsfw
 class ManhuaScan : FMReader("ManhuaScan", "https://manhuascan.com", "en") {
     override val client: OkHttpClient = super.client.newBuilder()
-        .addInterceptor(RateLimitInterceptor(1, period=1))
+        .addInterceptor(RateLimitInterceptor(1))
         .build()
     override fun fetchPageList(chapter: SChapter) = fetchPageListEncrypted(chapter)
 }

--- a/multisrc/overrides/fmreader/manhwahot/additional.gradle.kts
+++ b/multisrc/overrides/fmreader/manhwahot/additional.gradle.kts
@@ -1,0 +1,4 @@
+
+dependencies {
+    implementation project(':lib-ratelimit')
+}

--- a/multisrc/overrides/fmreader/manhwahot/src/ManhwaHot.kt
+++ b/multisrc/overrides/fmreader/manhwahot/src/ManhwaHot.kt
@@ -1,13 +1,15 @@
 package eu.kanade.tachiyomi.extension.en.manhwahot
 
+import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.annotations.Nsfw
 import eu.kanade.tachiyomi.multisrc.fmreader.FMReader
-import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.model.Page
-import okhttp3.Request
 import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.OkHttpClient
 
 @Nsfw
 class ManhwaHot : FMReader("ManhwaHot", "https://manhwahot.com", "en") {
+    override val client: OkHttpClient = super.client.newBuilder()
+        .addInterceptor(RateLimitInterceptor(1, period=1))
+        .build()
     override fun fetchPageList(chapter: SChapter) = fetchPageListEncrypted(chapter)
 }

--- a/multisrc/overrides/fmreader/manhwahot/src/ManhwaHot.kt
+++ b/multisrc/overrides/fmreader/manhwahot/src/ManhwaHot.kt
@@ -9,7 +9,7 @@ import okhttp3.OkHttpClient
 @Nsfw
 class ManhwaHot : FMReader("ManhwaHot", "https://manhwahot.com", "en") {
     override val client: OkHttpClient = super.client.newBuilder()
-        .addInterceptor(RateLimitInterceptor(1, period=1))
+        .addInterceptor(RateLimitInterceptor(1))
         .build()
     override fun fetchPageList(chapter: SChapter) = fetchPageListEncrypted(chapter)
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
@@ -17,17 +17,17 @@ class FMReaderGenerator : ThemeSourceGenerator {
 
     override val sources = listOf(
         SingleLang("Epik Manga", "https://www.epikmanga.com", "tr"),
-        SingleLang("HeroScan", "https://heroscan.com", "en", overrideVersionCode = 1),
+        SingleLang("HeroScan", "https://heroscan.com", "en", overrideVersionCode = 2),
         SingleLang("KissLove", "https://kissaway.net", "ja"),
         SingleLang("LHTranslation", "https://lhtranslation.net", "en", overrideVersionCode = 1),
         SingleLang("Manga-TR", "https://manga-tr.com", "tr", className = "MangaTR"),
-        SingleLang("ManhuaScan", "https://manhuascan.com", "en", isNsfw = true, overrideVersionCode = 2),
+        SingleLang("ManhuaScan", "https://manhuascan.com", "en", isNsfw = true, overrideVersionCode = 3),
         SingleLang("Manhwa18", "https://manhwa18.com", "en", isNsfw = true),
         MultiLang("Manhwa18.net", "https://manhwa18.net", listOf("en", "ko"), className = "Manhwa18NetFactory", isNsfw = true),
         SingleLang("RawLH", "https://lovehug.net", "ja"),
         SingleLang("Say Truyen", "https://saytruyen.com", "vi"),
         SingleLang("KSGroupScans", "https://ksgroupscans.com", "en"),
-        SingleLang("ManhwaHot", "https://manhwahot.com", "en", isNsfw = true),
+        SingleLang("ManhwaHot", "https://manhwahot.com", "en", isNsfw = true, overrideVersionCode=1),
         // Sites that went down
         //SingleLang("18LHPlus", "https://18lhplus.com", "en", className = "EighteenLHPlus"),
         //SingleLang("HanaScan (RawQQ)", "https://hanascan.com", "ja", className = "HanaScanRawQQ"),


### PR DESCRIPTION
alternate title: Play Cat and Mouse with HeroScan, ManhuaScan, and ManhwaHot

This pull request restores functionality to the aforementioned extensions and applies a harsh rate limiting limit.

Aside: There's no chance this fix survives the day. Once it breaks again, we'll probably have to declare them `won't fix`.

Closes #7055
Closes #7054