### PR TITLE
[Komga] search for `in progress` and `unread` when `unread only` filter is selected

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.26
+
+Minimum Komga version required: `0.87.4`
+
+### Fix
+
+* show series with only in progress books when searching for unread only
+
 ## 1.2.25
 
 Minimum Komga version required: `0.87.4`
@@ -5,7 +13,6 @@ Minimum Komga version required: `0.87.4`
 ### Fix
 
 * sort order for read list books
-
 
 ## 1.2.24
 

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 25
+    extVersionCode = 26
     libVersion = '1.2'
 }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -72,6 +72,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
                 is UnreadOnly -> {
                     if (filter.state) {
                         url.addQueryParameter("read_status", "UNREAD")
+                        url.addQueryParameter("read_status", "IN_PROGRESS")
                     }
                 }
                 is LibraryGroup -> {


### PR DESCRIPTION
Else a series with a single book in progress would not be shown. The same fix has been applied to the webui of Komga.