### PR TITLE
[Mangadex] Show Manga Cover from seperate API + UUID in description.

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 113
+    extVersionCode = 114
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
@@ -17,7 +17,7 @@ object MDConstants {
 
     //val tempCover = "https://i.imgur.com/6TrIues.jpg"
 
-    val coverApi = "coverapi.orell.dev/api/v1/mdaltimage/manga/{uuid}/cover"
+    val coverApi = "https://coverapi.orell.dev/api/v1/mdaltimage/manga/{uuid}/cover"
 
     const val mdAtHomeTokenLifespan = 5 * 60 * 1000
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
@@ -15,7 +15,9 @@ object MDConstants {
     val atHomePostUrl = "https://api.mangadex.network/report"
     val whitespaceRegex = "\\s".toRegex()
 
-    val tempCover = "https://i.imgur.com/6TrIues.jpg"
+    //val tempCover = "https://i.imgur.com/6TrIues.jpg"
+
+    val coverApi = "coverapi.orell.dev/api/v1/mdaltimage/manga/{uuid}/cover"
 
     const val mdAtHomeTokenLifespan = 5 * 60 * 1000
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -197,7 +197,7 @@ class MangaDexHelper() {
             return SManga.create().apply {
                 url = "/manga/$dexId"
                 title = cleanString(attr["title"]["en"].string)
-                description = cleanString(attr["description"]["en"].string)
+                description = cleanString(attr["description"]["en"].string).string + "\n\n\nManga UUID: $dexId"
                 author = authorIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 artist = artistIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 status = getPublicationStatus(attr["publicationDemographic"].nullString)

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -197,7 +197,7 @@ class MangaDexHelper() {
             return SManga.create().apply {
                 url = "/manga/$dexId"
                 title = cleanString(attr["title"]["en"].string)
-                description = cleanString(attr["description"]["en"].string).string + "\n\n\nManga UUID: $dexId"
+                description = cleanString(attr["description"]["en"].string) + "\n\n\nManga UUID: $dexId"
                 author = authorIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 artist = artistIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 status = getPublicationStatus(attr["publicationDemographic"].nullString)

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -131,7 +131,7 @@ class MangaDexHelper() {
         return SManga.create().apply {
             url = "/manga/$dexId"
             title = cleanString(attr["title"]["en"].string)
-            thumbnail_url = MDConstants.tempCover
+            thumbnail_url = MDConstants.coverApi.replace("{uuid}", dexId)
         }
     }
 
@@ -201,7 +201,7 @@ class MangaDexHelper() {
                 author = authorIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 artist = artistIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 status = getPublicationStatus(attr["publicationDemographic"].nullString)
-                thumbnail_url = MDConstants.tempCover
+                thumbnail_url = MDConstants.coverApi.replace("{uuid}", dexId)
                 genre = genreList.joinToString(", ")
             }
         } catch (e: Exception) {


### PR DESCRIPTION
Noticed the coverapi on Neko and now it's here.

Since everything redirects to mangadex.org this will help to see the Manga UUID until the frontend of the site is up.