### PR TITLE
Fix missing slash in api endpoint

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/guya/Guya.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/guya/Guya.kt
@@ -32,7 +32,7 @@ abstract class Guya(
 
     override val supportsLatest = false
 
-    private val scanlatorCacheUrl = "$baseUrl/api/get_all_groups"
+    private val scanlatorCacheUrl = "$baseUrl/api/get_all_groups/"
 
     override fun headersBuilder() = Headers.Builder().apply {
         add(

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/guya/GuyaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/guya/GuyaGenerator.kt
@@ -9,7 +9,7 @@ class GuyaGenerator : ThemeSourceGenerator {
 
     override val themeClass = "Guya"
 
-    override val baseVersionCode: Int = 1
+    override val baseVersionCode: Int = 2
 
     override val sources = listOf(
         SingleLang("Guya", "https://guya.moe", "en", overrideVersionCode = 18),


### PR DESCRIPTION
Endpoints of both guya.moe and danke.moe, ends with a slash. This saved a http request.
