### PR TITLE
Fix Jsoup NPE at Webtoons

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/webtoons/Webtoons.kt
@@ -148,7 +148,7 @@ open class Webtoons(
             val isThisLang = "$url".startsWith("$baseUrl/$langCode")
             if (! (couldBeWebtoonOrEpisode && isThisLang))
                 emptyResult
-            else{
+            else {
                 val potentialUrl = "${webtoonPath(url)}?title_no=$title_no"
                 fetchMangaDetails(SManga.create().apply { this.url = potentialUrl }).map {
                     it.url = potentialUrl
@@ -157,7 +157,6 @@ open class Webtoons(
             }
         } ?: emptyResult
     }
-
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = "$baseUrl/$langCode/search?keyword=$query".toHttpUrlOrNull()?.newBuilder()!!
@@ -186,19 +185,19 @@ open class Webtoons(
         val infoElement = document.select("#_asideDetail")
 
         val manga = SManga.create()
-        manga.title = document.selectFirst("h1.subj").text()
+        manga.title = document.selectFirst("h1.subj, h3.subj").text()
         manga.author = detailElement.select(".author:nth-of-type(1)").first()?.ownText()
         manga.artist = detailElement.select(".author:nth-of-type(2)").first()?.ownText() ?: manga.author
         manga.genre = detailElement.select(".genre").joinToString(", ") { it.text() }
         manga.description = infoElement.select("p.summary").text()
-        manga.status = infoElement.select("p.day_info").text().orEmpty().let { parseStatus(it) }
+        manga.status = infoElement.select("p.day_info").firstOrNull()?.text().orEmpty().toStatus()
         manga.thumbnail_url = parseDetailsThumbnail(document)
         return manga
     }
 
-    private fun parseStatus(status: String) = when {
-        status.contains("UP") -> SManga.ONGOING
-        status.contains("COMPLETED") -> SManga.COMPLETED
+    private fun String.toStatus(): Int = when {
+        contains("UP") -> SManga.ONGOING
+        contains("COMPLETED") -> SManga.COMPLETED
         else -> SManga.UNKNOWN
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/webtoons/WebtoonsGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/webtoons/WebtoonsGenerator.kt
@@ -13,7 +13,7 @@ class WebtoonsGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 1
 
     override val sources = listOf(
-        MultiLang("Webtoons.com", "https://www.webtoons.com", listOf("en", "fr", "es", "id", "th", "zh"), className = "WebtoonsFactory", pkgName = "webtoons", overrideVersionCode = 28),
+        MultiLang("Webtoons.com", "https://www.webtoons.com", listOf("en", "fr", "es", "id", "th", "zh"), className = "WebtoonsFactory", pkgName = "webtoons", overrideVersionCode = 29),
         SingleLang("Dongman Manhua", "https://www.dongmanmanhua.cn", "zh")
     )
 


### PR DESCRIPTION
Some pages in the challenge category uses another HTML tag for the title and may not have the status. This behavior was making the extension throw a `NullPointerException` when using the `text()` method in `mangaDetailsParse`.
