### PR TITLE
MangaMutiny - Migration from Gson to kotlinx.serialization

### DIFF
--- a/src/en/mangamutiny/build.gradle
+++ b/src/en/mangamutiny/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'Manga Mutiny'
     pkgNameSuffix = "en.mangamutiny"
     extClass = '.MangaMutiny'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
@@ -1,9 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.mangamutiny
 
 import android.net.Uri
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.Filter
@@ -13,28 +10,13 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
 import rx.Observable
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
-
-fun JsonObject.getNullable(key: String): JsonElement? {
-    val value: JsonElement = this.get(key) ?: return null
-
-    if (value.isJsonNull) {
-        return null
-    }
-
-    return value
-}
-
-fun Float.toStringWithoutDotZero(): String = when (this % 1) {
-    0F -> this.toInt().toString()
-    else -> this.toString()
-}
+import java.lang.IllegalStateException
 
 class MangaMutiny : HttpSource() {
 
@@ -45,7 +27,7 @@ class MangaMutiny : HttpSource() {
 
     override val lang = "en"
 
-    private val parser = JsonParser()
+    private val json = Json { ignoreUnknownKeys = true }
 
     private val baseUrlAPI = "https://api.mangamutiny.org"
 
@@ -78,63 +60,16 @@ class MangaMutiny : HttpSource() {
         mangaDetailsRequestCommon(manga, false)
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val chapterList = mutableListOf<SChapter>()
         val responseBody = response.body
 
-        if (responseBody != null) {
-            val jsonChapters = JsonParser().parse(responseBody.charStream()).asJsonObject
-                .get("chapters").asJsonArray
-            for (singleChapterJsonElement in jsonChapters) {
-                val singleChapterJsonObject = singleChapterJsonElement.asJsonObject
-
-                chapterList.add(
-                    SChapter.create().apply {
-                        name = chapterTitleBuilder(singleChapterJsonObject)
-                        url = singleChapterJsonObject.get("slug").asString
-                        date_upload = parseDate(singleChapterJsonObject.get("releasedAt").asString)
-
-                        chapterNumberBuilder(singleChapterJsonObject)?.let { chapterNumber ->
-                            chapter_number = chapterNumber
-                        }
-                    }
-                )
-            }
-
+        return if (responseBody != null) {
+            val result = json.decodeFromString<MangaMutinyItem>(responseBody.string())
             responseBody.close()
+            result.chapters?.map { it.toSChapter() } ?: listOf()
+        } else {
+            listOf()
         }
-
-        return chapterList
     }
-
-    private fun chapterNumberBuilder(rootNode: JsonObject): Float? =
-        rootNode.getNullable("chapter")?.asFloat
-
-    private fun chapterTitleBuilder(rootNode: JsonObject): String {
-        val volume = rootNode.getNullable("volume")?.asInt
-
-        val chapter = rootNode.getNullable("chapter")?.asFloat?.toStringWithoutDotZero()
-
-        val textTitle = rootNode.getNullable("title")?.asString
-
-        val chapterTitle = StringBuilder()
-        if (volume != null) chapterTitle.append("Vol. $volume")
-        if (chapter != null) {
-            if (volume != null) chapterTitle.append(" ")
-            chapterTitle.append("Chapter $chapter")
-        }
-        if (textTitle != null && textTitle != "") {
-            if (volume != null || chapter != null) chapterTitle.append(": ")
-            chapterTitle.append(textTitle)
-        }
-
-        return chapterTitle.toString()
-    }
-
-    private val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
-        .apply { timeZone = TimeZone.getTimeZone("UTC") }
-
-    private fun parseDate(dateAsString: String): Long =
-        dateFormatter.parse(dateAsString)?.time ?: 0
 
     // latest
     override fun latestUpdatesRequest(page: Int): Request =
@@ -162,32 +97,15 @@ class MangaMutiny : HttpSource() {
     }
 
     override fun mangaDetailsParse(response: Response): SManga {
-        val manga = SManga.create()
         val responseBody = response.body
 
         if (responseBody != null) {
-            val rootNode = parser.parse(responseBody.charStream()).asJsonObject
-            manga.apply {
-                status = when (rootNode.get("status").asString) {
-                    "ongoing" -> SManga.ONGOING
-                    "completed" -> SManga.COMPLETED
-                    else -> SManga.UNKNOWN
-                }
-                description = rootNode.getNullable("summary")?.asString
-                thumbnail_url = rootNode.getNullable("thumbnail")?.asString
-                title = rootNode.get("title").asString
-                url = rootNode.get("slug").asString
-                artist = rootNode.getNullable("artists")?.asString
-                author = rootNode.get("authors").asString
-
-                genre = rootNode.get("tags").asJsonArray
-                    .joinToString { singleGenre -> singleGenre.asString }
-            }
-
+            val result = json.decodeFromString<MangaMutinyItem>(responseBody.string()).toSManga()
             responseBody.close()
+            return result
+        } else {
+            throw IllegalStateException("Response code ${response.code}")
         }
-
-        return manga
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
@@ -199,31 +117,15 @@ class MangaMutiny : HttpSource() {
     }
 
     override fun pageListParse(response: Response): List<Page> {
-        val pageList = ArrayList<Page>()
-
         val responseBody = response.body
 
-        if (responseBody != null) {
-            val rootNode = parser.parse(responseBody.charStream()).asJsonObject
-
-            // Build chapter url for every image of this chapter
-            val storageLocation = rootNode.get("storage").asString
-            val manga = rootNode.get("manga").asString
-            val chapterId = rootNode.get("id").asString
-
-            val chapterUrl = "$storageLocation/$manga/$chapterId/"
-
-            // Process every image of this chapter
-            val images = rootNode.get("images").asJsonArray
-
-            for (i in 0 until images.size()) {
-                pageList.add(Page(i, "", chapterUrl + images[i].asString))
-            }
-
+        return if (responseBody != null) {
+            val result = json.decodeFromString<MangaMutinyPageResponse>(responseBody.string())
             responseBody.close()
+            result.toPageList()
+        } else {
+            listOf()
         }
-
-        return pageList
     }
 
     // Search
@@ -234,46 +136,25 @@ class MangaMutiny : HttpSource() {
 
     // commonly used functions
     private fun mangaParse(response: Response): MangasPage {
-        val mangasPage = ArrayList<SManga>()
         val responseBody = response.body
 
-        var totalObjects = 0
-
         if (responseBody != null) {
-            val rootNode = parser.parse(responseBody.charStream())
-
-            if (rootNode.isJsonObject) {
-                val rootObject = rootNode.asJsonObject
-                val itemsArray = rootObject.get("items").asJsonArray
-
-                for (singleItem in itemsArray) {
-                    val mangaObject = singleItem.asJsonObject
-                    mangasPage.add(
-                        SManga.create().apply {
-                            this.title = mangaObject.get("title").asString
-                            this.thumbnail_url = mangaObject.getNullable("thumbnail")?.asString
-                            this.url = mangaObject.get("slug").asString
-                        }
-                    )
-                }
-
-                // total number of manga the server found in its database
-                // and is returning paginated page by page:
-                totalObjects = rootObject.getNullable("total")?.asInt ?: 0
-            }
+            val result = json.decodeFromString<MangaMutinyMangasPageResponse>(responseBody.string())
 
             responseBody.close()
+
+            val mangasPage = result.items.map { it.toSManga() }
+
+            val totalObjects = result.total
+            val skipped = response.request.url.queryParameter("skip")?.toInt() ?: 0
+            val moreElementsToSkip = skipped + fetchAmount < totalObjects
+            val pageSizeEqualsFetchAmount = mangasPage.size == fetchAmount
+            val hasMorePages = pageSizeEqualsFetchAmount && moreElementsToSkip
+
+            return MangasPage(mangasPage, hasMorePages)
+        } else {
+            return MangasPage(listOf(), false)
         }
-
-        val skipped = response.request.url.queryParameter("skip")?.toInt() ?: 0
-
-        val moreElementsToSkip = skipped + fetchAmount < totalObjects
-
-        val pageSizeEqualsFetchAmount = mangasPage.size == fetchAmount
-
-        val hasMorePages = pageSizeEqualsFetchAmount && moreElementsToSkip
-
-        return MangasPage(mangasPage, hasMorePages)
     }
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutinySerialization.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutinySerialization.kt
@@ -1,0 +1,94 @@
+package eu.kanade.tachiyomi.extension.en.mangamutiny
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.serialization.Serializable
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+@Serializable
+data class MangaMutinyMangasPageResponse(val items: List<MangaMutinyItem>, val total: Int)
+
+@Serializable
+data class MangaMutinyItem(
+    val title: String,
+    val slug: String,
+    val thumbnail: String,
+    val status: String? = null,
+    val summary: String? = null,
+    val artists: String? = null,
+    val authors: String? = null,
+    val genre: List<String>? = null,
+    val chapters: List<MangaMutinyChapter>? = null
+) {
+    fun toSManga(): SManga = SManga.create().apply {
+        this.title = this@MangaMutinyItem.title
+        this.thumbnail_url = this@MangaMutinyItem.thumbnail
+        this.url = this@MangaMutinyItem.slug
+
+        this.status = when (this@MangaMutinyItem.status) {
+            "ongoing" -> SManga.ONGOING
+            "completed" -> SManga.COMPLETED
+            else -> SManga.UNKNOWN
+        }
+        this.description = this@MangaMutinyItem.summary
+        this.artist = this@MangaMutinyItem.artists
+        this.author = this@MangaMutinyItem.authors
+        this.genre = this@MangaMutinyItem.genre?.joinToString()
+    }
+}
+
+@Serializable
+data class MangaMutinyPageResponse(
+    val storage: String,
+    val manga: String,
+    val id: String,
+    val images: List<String>
+) {
+    private val chapterUrl = "$storage/$manga/$id/"
+    fun toPageList(): List<Page> =
+        images.mapIndexed { index, pageSuffix -> Page(index, "", chapterUrl + pageSuffix) }
+}
+
+@Serializable
+data class MangaMutinyChapter(
+    val volume: Int?,
+    val chapter: Float,
+    val title: String?,
+    val slug: String,
+    val releasedAt: String
+) {
+    companion object {
+        private val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+        /**
+         * Converts this Float into a String, removing any trailing .0
+         */
+        fun Float.toStringWithoutDotZero(): String = when (this % 1) {
+            0F -> this.toInt().toString()
+            else -> this.toString()
+        }
+    }
+
+    private fun chapterTitleBuilder(): String {
+        val chapterTitle = StringBuilder()
+        if (volume != null) {
+            chapterTitle.append("Vol. $volume ")
+        }
+        chapterTitle.append("Chapter ${chapter.toStringWithoutDotZero()}")
+        if (title != null && title != "") {
+            chapterTitle.append(": $title")
+        }
+        return chapterTitle.toString()
+    }
+
+    fun toSChapter(): SChapter = SChapter.create().apply {
+        this.name = this@MangaMutinyChapter.chapterTitleBuilder()
+        this.url = this@MangaMutinyChapter.slug
+        this.date_upload = dateFormatter.parse(releasedAt)?.time ?: 0
+        this.chapter_number = this@MangaMutinyChapter.chapter
+    }
+}

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutinySerialization.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutinySerialization.kt
@@ -3,92 +3,181 @@ package eu.kanade.tachiyomi.extension.en.mangamutiny
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 
-@Serializable
-data class MangaMutinyMangasPageResponse(val items: List<MangaMutinyItem>, val total: Int)
+private fun JsonElement?.primitiveContent(): String? {
+    if (this is JsonNull) return null
+    return this?.jsonPrimitive?.content
+}
+private fun JsonElement?.primitiveInt(): Int? {
+    if (this is JsonNull) return null
+    return this?.jsonPrimitive?.int
+}
+private fun JsonElement?.primitiveFloat(): Float? {
+    if (this is JsonNull) return null
+    return this?.jsonPrimitive?.float
+}
 
-@Serializable
-data class MangaMutinyItem(
-    val title: String,
-    val slug: String,
-    val thumbnail: String,
-    val status: String? = null,
-    val summary: String? = null,
-    val artists: String? = null,
-    val authors: String? = null,
-    val genre: List<String>? = null,
-    val chapters: List<MangaMutinyChapter>? = null
-) {
-    fun toSManga(): SManga = SManga.create().apply {
-        this.title = this@MangaMutinyItem.title
-        this.thumbnail_url = this@MangaMutinyItem.thumbnail
-        this.url = this@MangaMutinyItem.slug
+private val jsonObjectToMapSerializer = MapSerializer(String.serializer(), JsonElement.serializer())
 
-        this.status = when (this@MangaMutinyItem.status) {
-            "ongoing" -> SManga.ONGOING
-            "completed" -> SManga.COMPLETED
-            else -> SManga.UNKNOWN
-        }
-        this.description = this@MangaMutinyItem.summary
-        this.artist = this@MangaMutinyItem.artists
-        this.author = this@MangaMutinyItem.authors
-        this.genre = this@MangaMutinyItem.genre?.joinToString()
+object PageInfoDS : DeserializationStrategy<Pair<List<SManga>, Int>> {
+    override val descriptor: SerialDescriptor = jsonObjectToMapSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): Pair<List<SManga>, Int> {
+        require(decoder is JsonDecoder)
+        val json = decoder.json
+        val jsonElement = decoder.decodeJsonElement()
+        require(jsonElement is JsonObject)
+        val items = (jsonElement["items"] as JsonArray).map { json.decodeFromJsonElement(SMangaDS, it) }
+        val total = jsonElement["total"]?.jsonPrimitive?.int
+
+        require(total != null)
+        return Pair(items, total)
     }
 }
 
-@Serializable
-data class MangaMutinyPageResponse(
-    val storage: String,
-    val manga: String,
-    val id: String,
-    val images: List<String>
-) {
-    private val chapterUrl = "$storage/$manga/$id/"
-    fun toPageList(): List<Page> =
-        images.mapIndexed { index, pageSuffix -> Page(index, "", chapterUrl + pageSuffix) }
+object SMangaDS : DeserializationStrategy<SManga> {
+    override val descriptor: SerialDescriptor = jsonObjectToMapSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): SManga {
+        require(decoder is JsonDecoder)
+        val jsonElement = decoder.decodeJsonElement()
+        require(jsonElement is JsonObject)
+        val title = jsonElement["title"].primitiveContent()
+        val slug = jsonElement["slug"].primitiveContent()
+        val thumbnail = jsonElement["thumbnail"].primitiveContent()
+
+        val status: Int = jsonElement["status"].primitiveContent()?.let {
+            when (it) {
+                "ongoing" -> SManga.ONGOING
+                "completed" -> SManga.COMPLETED
+                else -> SManga.UNKNOWN
+            }
+        } ?: SManga.UNKNOWN
+
+        val summary: String? = jsonElement["summary"].primitiveContent()
+        val artists: String? = jsonElement["artists"].primitiveContent()
+        val authors: String? = jsonElement["authors"].primitiveContent()
+        val tags: String? =
+            jsonElement["tags"]?.jsonArray?.mapNotNull { it.primitiveContent() }?.joinToString()
+
+        require(title != null && slug != null)
+        return SManga.create().apply {
+            this.title = title
+            this.url = slug
+            this.thumbnail_url = thumbnail
+
+            this.status = status
+            this.description = summary
+            this.artist = artists
+            this.author = authors
+            this.genre = tags
+        }
+    }
 }
 
-@Serializable
-data class MangaMutinyChapter(
-    val volume: Int?,
-    val chapter: Float,
-    val title: String?,
-    val slug: String,
-    val releasedAt: String
-) {
-    companion object {
-        private val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
-            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+object ListChapterDS : DeserializationStrategy<List<SChapter>> {
+    override val descriptor: SerialDescriptor = jsonObjectToMapSerializer.descriptor
 
-        /**
-         * Converts this Float into a String, removing any trailing .0
-         */
-        fun Float.toStringWithoutDotZero(): String = when (this % 1) {
-            0F -> this.toInt().toString()
-            else -> this.toString()
+    override fun deserialize(decoder: Decoder): List<SChapter> {
+        require(decoder is JsonDecoder)
+        val json = decoder.json
+        val jsonElement = decoder.decodeJsonElement()
+        require(jsonElement is JsonObject)
+
+        val jsonElementChapters = jsonElement["chapters"]?.jsonArray
+        require(jsonElementChapters != null)
+
+        return jsonElementChapters.map { chapter ->
+            json.decodeFromJsonElement(SChapterDS, chapter)
+        }.apply {
+            if (this.size == 1) this.first().chapter_number = 1F
+        }
+    }
+}
+
+private object SChapterDS : DeserializationStrategy<SChapter> {
+
+    override val descriptor: SerialDescriptor = jsonObjectToMapSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): SChapter {
+        require(decoder is JsonDecoder)
+        val jsonElement = decoder.decodeJsonElement()
+        require(jsonElement is JsonObject)
+        val volume: Int? = jsonElement["volume"].primitiveInt()
+        val chapter: Float? = jsonElement["chapter"].primitiveFloat()
+        val title: String? = jsonElement["title"].primitiveContent()
+        val slug: String? = jsonElement["slug"].primitiveContent()
+        val releasedAt: String? = jsonElement["releasedAt"].primitiveContent()
+
+        require(slug != null && releasedAt != null)
+        return SChapter.create().apply {
+            if (chapter != null) this.chapter_number = chapter
+            this.name = chapterTitleBuilder(volume, title, chapter)
+            this.url = slug
+            this.date_upload = dateFormatter.parse(releasedAt)?.time ?: 0
         }
     }
 
-    private fun chapterTitleBuilder(): String {
+    private val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
+        .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+    /**
+     * Converts this Float into a String, removing any trailing .0
+     */
+    private fun Float.toStringWithoutDotZero(): String = when (this % 1) {
+        0F -> this.toInt().toString()
+        else -> this.toString()
+    }
+
+    private fun chapterTitleBuilder(volume: Int?, title: String?, chapter: Float?): String {
         val chapterTitle = StringBuilder()
         if (volume != null) {
             chapterTitle.append("Vol. $volume ")
         }
-        chapterTitle.append("Chapter ${chapter.toStringWithoutDotZero()}")
+        if (chapter != null) {
+            chapterTitle.append("Chapter ${chapter.toStringWithoutDotZero()}")
+        }
         if (title != null && title != "") {
-            chapterTitle.append(": $title")
+            if (chapterTitle.isNotEmpty()) chapterTitle.append(": ")
+            chapterTitle.append(title)
         }
         return chapterTitle.toString()
     }
+}
 
-    fun toSChapter(): SChapter = SChapter.create().apply {
-        this.name = this@MangaMutinyChapter.chapterTitleBuilder()
-        this.url = this@MangaMutinyChapter.slug
-        this.date_upload = dateFormatter.parse(releasedAt)?.time ?: 0
-        this.chapter_number = this@MangaMutinyChapter.chapter
+object ListPageDS : DeserializationStrategy<List<Page>> {
+    override val descriptor: SerialDescriptor = jsonObjectToMapSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): List<Page> {
+        require(decoder is JsonDecoder)
+        val jsonElement = decoder.decodeJsonElement()
+        require(jsonElement is JsonObject)
+
+        val storage: String? = jsonElement["storage"].primitiveContent()
+        val manga: String? = jsonElement["manga"].primitiveContent()
+        val id: String? = jsonElement["id"].primitiveContent()
+        val images: List<String>? =
+            jsonElement["images"]?.jsonArray?.mapNotNull { it.primitiveContent() }
+
+        require(storage != null && manga != null && id != null && images != null)
+        val chapterUrl = "$storage/$manga/$id/"
+        return images.mapIndexed { index, pageSuffix -> Page(index, "", chapterUrl + pageSuffix) }
     }
 }


### PR DESCRIPTION
With the changes of this pull request I'm getting rid of the GSON library for the MangaMutiny extension and instead use kotlinx.serialization (reason for this change is #7392).

The changes made with this pull request will not affect extension users.

I avoided adding data classes annotated with Serializable, since I did not want to introduce additional classes to the extension. DeserializationStrategy objects can be just as useful and don't require lots of instances at runtime.