### PR TITLE
Fix chapter names in FallenAngels

### DIFF
--- a/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
+++ b/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
@@ -31,7 +31,6 @@ class FallenAngels : MMRCMS("Fallen Angels", "https://manga.fascans.com", "en") 
         val chapter = SChapter.create()
 
         val titleWrapper = element.select("[class^=chapter-title-rtl]").first()
-        val urlRegex = Regex("""[a-zA-z]""")
         val chapterElement = titleWrapper.getElementsByTag("a")
         val url = chapterElement.attr("href")
 

--- a/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
+++ b/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
@@ -1,0 +1,66 @@
+package eu.kanade.tachiyomi.extension.pt.gekkouscan
+
+import eu.kanade.tachiyomi.multisrc.mmrcms.MMRCMS
+
+class FallenAngels : MMRCMS("Fallen Angels", "https://manga.fascans.com", "en") {
+
+    /**
+     * Parses the response from the site and returns a list of chapters.
+     *
+     * Overriden to allow for null chapters
+     *
+     * @param response the response from the site.
+     */
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val document = response.asJsoup()
+        return document.select(chapterListSelector()).mapNotNull { nullableChapterFromElement(it) }
+    }
+
+    /**
+     * Returns a chapter from the given element.
+     *
+     * @param element an element obtained from [chapterListSelector].
+     */
+    override fun nullableChapterFromElement(element: Element): SChapter? {
+        val chapter = SChapter.create()
+
+        try {
+            val titleWrapper = if (name == "Mangas.pw") element.select("i a").first() else element.select("[class^=chapter-title-rtl]").first()
+            // Some websites add characters after "..-rtl" thus the need of checking classes that starts with that
+            val url = titleWrapper.getElementsByTag("a")
+                .first { it.attr("href").contains(urlRegex) }
+                .attr("href")
+
+            // Ensure chapter actually links to a manga
+            // Some websites use the chapters box to link to post announcements
+            // The check is skipped if mangas are stored in the root of the website (ex '/one-piece' without a segment like '/manga/one-piece')
+            if (itemUrlPath != null && !Uri.parse(url).pathSegments.firstOrNull().equals(itemUrlPath, true)) {
+                return null
+            }
+
+            chapter.url = getUrlWithoutBaseUrl(url)
+            chapter.name = titleWrapper.text()
+
+            // Parse date
+            val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()
+            chapter.date_upload = parseDate(dateText)
+
+            return chapter
+        } catch (e: NullPointerException) {
+            // For chapter list in a table
+            if (element.select("td").hasText()) {
+                element.select("td a").let {
+                    chapter.setUrlWithoutDomain(it.attr("href"))
+                    chapter.name = it.text()
+                }
+                val tableDateText = element.select("td + td").text()
+                chapter.date_upload = parseDate(tableDateText)
+
+                return chapter
+            }
+        }
+
+        return null
+    }
+
+}

--- a/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
+++ b/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
@@ -25,21 +25,21 @@ class FallenAngels : MMRCMS("Fallen Angels", "https://manga.fascans.com", "en") 
         val chapter = SChapter.create()
 
         try {
-            val titleWrapper = if (name == "Mangas.pw") element.select("i a").first() else element.select("[class^=chapter-title-rtl]").first()
-            // Some websites add characters after "..-rtl" thus the need of checking classes that starts with that
-            val url = titleWrapper.getElementsByTag("a")
+            val titleWrapper = element.select("[class^=chapter-title-rtl]").first()
+            val chapterElement = titleWrapper.getElementsByTag("a")
                 .first { it.attr("href").contains(urlRegex) }
-                .attr("href")
-
-            // Ensure chapter actually links to a manga
-            // Some websites use the chapters box to link to post announcements
-            // The check is skipped if mangas are stored in the root of the website (ex '/one-piece' without a segment like '/manga/one-piece')
-            if (itemUrlPath != null && !Uri.parse(url).pathSegments.firstOrNull().equals(itemUrlPath, true)) {
-                return null
-            }
+            val url = chapterElement.attr("href")
 
             chapter.url = getUrlWithoutBaseUrl(url)
-            chapter.name = titleWrapper.text()
+
+            // Construct chapter names
+            // before -> <mangaName> <chapterNumber> : <chapterTitle>
+            // after  -> Chapter     <chapterNumber> : <chapterTitle>
+            val chapterText = chapterElement.text()
+            val numberRegex = Regex("""\d+""")
+            val chapterNumber = numberRegex.find(chapterText)
+            val chapterTitle = chapterText.substringAfter(":")
+            chapter.name = "Chapter $chapterNumber : $chapterTitle"// titleWrapper.text()
 
             // Parse date
             val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSSources.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSSources.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.multisrc.mmrcms
 
 import java.util.Locale
 
-
 class MMRCMSSources {
     companion object {
         sealed class SourceData {
@@ -37,7 +36,7 @@ class MMRCMSSources {
         val sourceList: List<SourceData.Single> = listOf(
             SourceData.Single("مانجا اون لاين", "https://onma.me", "ar", className = "onma"),
             SourceData.Single("Read Comics Online", "https://readcomicsonline.ru", "en"),
-            SourceData.Single("Fallen Angels", "https://manga.fascans.com", "en"),
+            SourceData.Single("Fallen Angels", "https://manga.fascans.com", "en", overrideVersionCode = 1),
             SourceData.Single("Zahard", "https://zahard.top", "en", overrideVersionCode = 1),
             SourceData.Single("Manhwas Men", "https://manhwas.men", "en", isNsfw = true, overrideVersionCode = 1),
             SourceData.Single("Scan FR", "https://www.scan-fr.cc", "fr"),
@@ -73,8 +72,6 @@ class MMRCMSSources {
         )
     }
 }
-
-
 
 //SingleLang("Mangás Yuri", "https://mangasyuri.net", "pt-BR", className = "MangasYuri"), override val id: Long = 6456162511058446409
 //SingleLang("FR Scan", "https://www.frscan.me", "fr"),


### PR DESCRIPTION

Problem:
it is difficult to know chapter numbers for Manga titles with long chapter names or manga names like (Destroy All Humankind. They Can’t Be Regenerated.)

Fix:
added a new override for the chapterListParse method for the FallenAngels source in MMRCMS Generator

Notes:
since the chapter URL is unchanged, downloads wouldn't be affected. Checked on a oneshot chapter I had kept downloaded and it worked fine after the change

Changes:
previously -> mangaName chapterNumber : chapterTitle
new          ->         Chapter chapterNumber : chapterTitle

Screenshots : 

| Before | After |
|----------|---------|
|![Screenshot_20210604-013513_TachiyomiSY](https://user-images.githubusercontent.com/72807749/120860868-fa067380-c5a3-11eb-840f-5d83517f12ca.png)  | ![Screenshot_20210605-003015_TachiyomiSY](https://user-images.githubusercontent.com/72807749/120860871-fc68cd80-c5a3-11eb-8a1e-1a0b26d13d20.png) |