### PR TITLE
Use TrimMargin instead of listOf in xkcd string thrown on error

### DIFF
--- a/src/en/xkcd/build.gradle
+++ b/src/en/xkcd/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'xkcd'
     pkgNameSuffix = 'en.xkcd'
     extClass = '.Xkcd'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/en/xkcd/src/eu/kanade/tachiyomi/extension/en/xkcd/Xkcd.kt
+++ b/src/en/xkcd/src/eu/kanade/tachiyomi/extension/en/xkcd/Xkcd.kt
@@ -59,11 +59,11 @@ class Xkcd : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val titleWords: Sequence<String>
         val altTextWords: Sequence<String>
-        val interactiveText = listOf(
-            "To experience the", "interactive version of this comic,",
-            "open it in WebView/browser."
-        )
-            .joinToString(separator = "%0A")
+        val interactiveText = """
+            |To experience the interactive version of this comic,
+            |open it in WebView/browser.
+        """.trimMargin("|")
+            .replace("\n", "%0A")
             .replace(" ", "%20")
 
         // transforming filename from info.0.json isn't guaranteed to work, stick to html


### PR DESCRIPTION
makes a minor change to code I PRd a while back
(refer: #6474)

changed listOf to trimMargin because it looked cleaner and a more kotlin
way to do it

was unsure whether to bump build.gradle for this but I guess, its required anyways