### PR TITLE
Fix regex for chapterNumber in FAScans

### DIFF
--- a/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
+++ b/multisrc/overrides/mmrcms/fallenangels/src/FallenAngels.kt
@@ -40,10 +40,10 @@ class FallenAngels : MMRCMS("Fallen Angels", "https://manga.fascans.com", "en") 
         // before -> <mangaName> <chapterNumber> : <chapterTitle>
         // after  -> Chapter     <chapterNumber> : <chapterTitle>
         val chapterText = chapterElement.text()
-        val numberRegex = Regex("""\d+""")
+        val numberRegex = Regex("""[1-9]\d*(\.\d+)*""")
         val chapterNumber = numberRegex.find(chapterText)?.value.orEmpty()
         val chapterTitle = titleWrapper.getElementsByTag("em").text()
-        chapter.name = "Chapter $chapterNumber : $chapterTitle"// titleWrapper.text()
+        chapter.name = "Chapter $chapterNumber : $chapterTitle"
 
         // Parse date
         val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSSources.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSSources.kt
@@ -36,7 +36,7 @@ class MMRCMSSources {
         val sourceList: List<SourceData.Single> = listOf(
             SourceData.Single("مانجا اون لاين", "https://onma.me", "ar", className = "onma"),
             SourceData.Single("Read Comics Online", "https://readcomicsonline.ru", "en"),
-            SourceData.Single("Fallen Angels", "https://manga.fascans.com", "en", overrideVersionCode = 1),
+            SourceData.Single("Fallen Angels", "https://manga.fascans.com", "en", overrideVersionCode = 2),
             SourceData.Single("Zahard", "https://zahard.top", "en", overrideVersionCode = 1),
             SourceData.Single("Manhwas Men", "https://manhwas.men", "en", isNsfw = true, overrideVersionCode = 1),
             SourceData.Single("Scan FR", "https://www.scan-fr.cc", "fr"),


### PR DESCRIPTION
missed this in #7469 because I overlooked it, my bad XD

| previously | new |
|---------------|-------|
| `d+`          | `[1-9]\d*(\.\d+)*` |

the regex should now get correct chapter numbers for better chapters names 
while I only saw examples like chapter 64.5, the regex should be able to handle 64.5.5 as well (even though I couldn't find it)