### PR TITLE
Use correct field when parsing manga pub status

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 117
+    extVersionCode = 118
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -205,7 +205,7 @@ class MangaDexHelper() {
                 description = cleanString(attr["description"]["en"].string)
                 author = authorIds.mapNotNull { authorMap[it] }.joinToString(", ")
                 artist = artistIds.mapNotNull { authorMap[it] }.joinToString(", ")
-                status = getPublicationStatus(attr["publicationDemographic"].nullString)
+                status = getPublicationStatus(attr["status"].nullString)
                 thumbnail_url = getCoverUrl(dexId, coverId, client)
                 genre = genreList.joinToString(", ")
             }


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
After migrating all of my manga from (old) MangaDex to (new) MangaDex, I noticed that all of the statuses were showing up as 'Unknown', despite the api returning the correct status.

Note: this does nothing to address the 'completed' or 'canceled' statuses that MangaDex can return