### PR TITLE
Hentaimimi fix

### DIFF
--- a/src/en/hentaimimi/build.gradle
+++ b/src/en/hentaimimi/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'HentaiMimi'
     pkgNameSuffix = 'en.hentaimimi'
     extClass = '.HentaiMimi'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/hentaimimi/src/eu/kanade/tachiyomi/extension/en/hentaimimi/HentaiMimi.kt
+++ b/src/en/hentaimimi/src/eu/kanade/tachiyomi/extension/en/hentaimimi/HentaiMimi.kt
@@ -152,7 +152,7 @@ class HentaiMimi : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         document.select("body main script").html().substringAfter("[").substringBefore("]").split("\",\"").forEachIndexed { index, it ->
-            val url = "$baseUrl/${it.replace("\\", "").replace("\"", "")}"
+            val url = "$baseUrl/${it.replace("\\/", "/").replace("\"", "")}"
             pages.add(Page(index, url, url))
         }
 


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->

I've noticed some books could not be viewed due to them having unicode entities in page URLs, like this: `"uploads\/zip_files\/extracted\/\u201cFirst Step\u201d\/001.webp".`
The extension cuts extensions incorrectly everywhere, but instead it must cut only "\/" sequence.

Example of such book: https://hentaimimi.com/view/3