### PR TITLE
Add deeplinking to MangaPlus and Tsuki

### DIFF
--- a/src/all/mangaplus/AndroidManifest.xml
+++ b/src/all/mangaplus/AndroidManifest.xml
@@ -1,2 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="eu.kanade.tachiyomi.extension" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.extension">
+
+    <application>
+        <activity
+            android:name=".all.mangaplus.MangaPlusUrlActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="mangaplus.shueisha.co.jp"
+                    android:pathPattern="/titles/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="www.mangaplus.shueisha.co.jp"
+                    android:pathPattern="/titles/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 19
+    extVersionCode = 20
     libVersion = '1.2'
 }
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusUrlActivity.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusUrlActivity.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.extension.all.mangaplus
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class MangaPlusUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            val titleId = pathSegments[1]
+
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", MangaPlus.PREFIX_ID_SEARCH + titleId)
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("MangaPlusUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("MangaPlusUrlActivity", "Could not parse URI from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}

--- a/src/pt/tsukimangas/AndroidManifest.xml
+++ b/src/pt/tsukimangas/AndroidManifest.xml
@@ -1,2 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="eu.kanade.tachiyomi.extension" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.extension">
+
+    <application>
+        <activity
+            android:name=".pt.tsukimangas.TsukiMangasUrlActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="tsukimangas.com"
+                    android:pathPattern="/obra/..*/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="www.tsukimangas.com"
+                    android:pathPattern="/obra/..*/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/pt/tsukimangas/build.gradle
+++ b/src/pt/tsukimangas/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Tsuki Mangás'
     pkgNameSuffix = 'pt.tsukimangas'
     extClass = '.TsukiMangas'
-    extVersionCode = 18
+    extVersionCode = 19
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/pt/tsukimangas/src/eu/kanade/tachiyomi/extension/pt/tsukimangas/TsukiMangasUrlActivity.kt
+++ b/src/pt/tsukimangas/src/eu/kanade/tachiyomi/extension/pt/tsukimangas/TsukiMangasUrlActivity.kt
@@ -1,0 +1,37 @@
+package eu.kanade.tachiyomi.extension.pt.tsukimangas
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class TsukiMangasUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            val titleId = pathSegments[1]
+
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", TsukiMangas.PREFIX_ID_SEARCH + titleId)
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("TsukiMangasUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("TsukiMangasUrlActivity", "Could not parse URI from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
Both websites are single page applications, so Chrome doesn't prompt the open at dialog.

However, Android prompts the dialog when clicking in links through other apps or with `adb` as below.

```console
$ adb shell am start -d "https://tsukimangas.com/obra/5578/lingwu-emperor" -a android.intent.action.VIEW
Starting: Intent { act=android.intent.action.VIEW dat=https://tsukimangas.com/... }

$ adb shell am start -d "https://mangaplus.shueisha.co.jp/titles/100001" -a android.intent.action.VIEW
Starting: Intent { act=android.intent.action.VIEW dat=https://mangaplus.shueisha.co.jp/... }
```