### PR TITLE
Hentaimimi proper fix

### DIFF
--- a/src/en/hentaimimi/build.gradle
+++ b/src/en/hentaimimi/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'HentaiMimi'

--- a/src/en/hentaimimi/build.gradle
+++ b/src/en/hentaimimi/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'HentaiMimi'
     pkgNameSuffix = 'en.hentaimimi'
     extClass = '.HentaiMimi'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
The previous pull request #7574 didn't fix the slashes issue. I'm really sorry for submitting not working fix.

To fix my situation, I had to put my hands in Kotlin and figure out how to fix the parsing of the list of pages. It turns out that simple js arrays, such as a list of pages on their site, can be parsed as json, and you don't have to bother with handling escaped strings at all.

This time, I carefully checked and tested on a device that the changes worked, and additionally checked other special elements such as ?, #, @, /, [, ] too - all pages parsed without errors.