### PR TITLE
Add in error handling to handle malformed responses from the aggregate endpoint

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 120
+    extVersionCode = 121
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
Addresses #7697 and #7678, albeit by just swallowing the error case.  The MangaDex team is aware of the root issue and have an issue logged to address the root cause.