### PR TITLE
zh-dmzj: replace dmzj.com with dmzj1.com for v4api only to make it work again

### DIFF
--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Dmzj'
     pkgNameSuffix = 'zh.dmzj'
     extClass = '.Dmzj'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
+++ b/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
@@ -48,7 +48,7 @@ class Dmzj : ConfigurableSource, HttpSource() {
     private val v3apiUrl = "https://v3api.dmzj.com"
     private val v3ChapterApiUrl = "https://nnv3api.dmzj.com"
     // v3api now shutdown the functionality to fetch manga detail and chapter list, so move these logic to v4api
-    private val v4apiUrl = "https://nnv4api.dmzj.com" // https://v4api.dmzj.com
+    private val v4apiUrl = "https://nnv4api.dmzj1.com" // https://v4api.dmzj1.com
     private val apiUrl = "https://api.dmzj.com"
     private val oldPageListApiUrl = "https://api.m.dmzj.com"
     private val webviewPageListApiUrl = "https://m.dmzj.com/chapinfo"


### PR DESCRIPTION
The new v4api doesn't work if using `nnv4api.dmzj.com` as api url, only `nnv4api.dmzj1.com` works. The `dmzj.com` version will always return an error message indicating `暂时无法观看` (with errno `3`) even if the manga is not blocked (i.e. can read directly from website).

The `dmzj1.com` domain is back online again, including its websites: https://www.dmzj1.com/ ([archive](https://web.archive.org/web/20210617223910/https://www.dmzj1.com/)) and https://manhua.dmzj1.com/ ([archive](https://web.archive.org/web/20210617224035/https://manhua.dmzj1.com/)). The previous issue (https://github.com/tachiyomiorg/tachiyomi-extensions/issues/7668) may be just a DNS misconfiguration incident. I only reverted change of v4api because it seems that other apis still work under `dmzj.com`, only v4api breaks.