### PR TITLE
Flame Scans: Harsher Rate Limit + Add Tachiyomi Identifier to User Agent

### DIFF
--- a/multisrc/overrides/wpmangareader/flamescans/src/FlameScans.kt
+++ b/multisrc/overrides/wpmangareader/flamescans/src/FlameScans.kt
@@ -2,11 +2,15 @@ package eu.kanade.tachiyomi.extension.en.flamescans
 
 import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.multisrc.wpmangareader.WPMangaReader
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
 class FlameScans : WPMangaReader("Flame Scans", "https://flamescans.org", "en", "/series") {
-    private val rateLimitInterceptor = RateLimitInterceptor(2)
+    private val rateLimitInterceptor = RateLimitInterceptor(1)
+    private val userAgent = "Tachiyomi Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"
+    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("User-Agent", userAgent)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .connectTimeout(10, TimeUnit.SECONDS)
@@ -14,3 +18,4 @@ class FlameScans : WPMangaReader("Flame Scans", "https://flamescans.org", "en", 
         .addNetworkInterceptor(rateLimitInterceptor)
         .build()
 }
+

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
@@ -22,7 +22,7 @@ class WPMangaReaderGenerator : ThemeSourceGenerator {
         SingleLang("Mangasusu", "https://mangasusu.co.in", "id", isNsfw = true),
         SingleLang("TurkToon", "https://turktoon.com", "tr"),
         SingleLang("Gecenin Lordu", "https://geceninlordu.com/", "tr", overrideVersionCode = 1),
-        SingleLang("Flame Scans", "https://flamescans.org", "en", overrideVersionCode = 3),
+        SingleLang("Flame Scans", "https://flamescans.org", "en", overrideVersionCode = 4),
         SingleLang("A Pair of 2+", "https://pairof2.com", "en", className = "APairOf2"),
         SingleLang("PMScans", "https://reader.pmscans.com", "en"),
         SingleLang("Skull Scans", "https://www.skullscans.com", "en"),


### PR DESCRIPTION
* Reduced request limit to 1 request / second
* Traffic from Tachiyomi is identified by the word "Tachiyomi" in the user agent.