### PR TITLE
Kotlinx.serialization migration for several sources

### DIFF
--- a/src/all/batoto/build.gradle
+++ b/src/all/batoto/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'Bato.to'
     pkgNameSuffix = 'all.batoto'
     extClass = '.BatoToFactory'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -11,17 +11,20 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.json.JSONArray
-import org.json.JSONObject
+import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import rx.Observable
+import uy.kohesive.injekt.injectLazy
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
-import okhttp3.Response
-import rx.Observable
 
 open class BatoTo(
     override val lang: String,
@@ -32,7 +35,7 @@ open class BatoTo(
     override val baseUrl: String = "https://bato.to"
 
     override val supportsLatest = true
-
+    private val json: Json by injectLazy()
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
@@ -100,7 +103,7 @@ open class BatoTo(
                 val url = "$baseUrl/browse".toHttpUrlOrNull()!!.newBuilder()
                 url.addQueryParameter("page", page.toString())
 
-                with (langFilter) {
+                with(langFilter) {
                     if (this.selected.isEmpty()) {
                         url.addQueryParameter("langs", siteLang)
                     } else {
@@ -109,20 +112,21 @@ open class BatoTo(
                     }
                 }
 
-                with (genreFilter) {
-                    url.addQueryParameter("genres", included.joinToString(",") + "|" + excluded.joinToString(",")
+                with(genreFilter) {
+                    url.addQueryParameter(
+                        "genres", included.joinToString(",") + "|" + excluded.joinToString(",")
                     )
                 }
 
-                with (statusFilter) {
+                with(statusFilter) {
                     url.addQueryParameter("release", this.selected)
                 }
 
-                with (sortFilter) {
+                with(sortFilter) {
                     if (reverseSortFilter.state) {
-                        url.addQueryParameter("sort","${this.selected}.az")
+                        url.addQueryParameter("sort", "${this.selected}.az")
                     } else {
-                        url.addQueryParameter("sort","${this.selected}.za")
+                        url.addQueryParameter("sort", "${this.selected}.za")
                     }
                 }
 
@@ -294,16 +298,8 @@ open class BatoTo(
         val script = document.select("script").html()
 
         if (script.contains("var images =")) {
-            val imgJson = JSONObject(script.substringAfter("var images = ").substringBefore(";"))
-            val imgNames = imgJson.names()
-
-            if (imgNames != null) {
-                for (i in 0 until imgNames.length()) {
-                    val imgKey = imgNames.getString(i)
-                    val imgUrl = imgJson.getString(imgKey)
-                    pages.add(Page(i, "", imgUrl))
-                }
-            }
+            val imgJson = json.parseToJsonElement(script.substringAfter("var images = ").substringBefore(";")).jsonObject
+            imgJson.keys.forEachIndexed { i, s -> pages.add(Page(i, imageUrl = imgJson[s]!!.jsonPrimitive.content)) }
         } else if (script.contains("const server =")) { // bato.to
             val duktape = Duktape.create()
             val encryptedServer = script.substringAfter("const server = ").substringBefore(";")
@@ -312,23 +308,15 @@ open class BatoTo(
             val server = duktape.evaluate(decryptScript).toString().replace("\"", "")
             duktape.close()
 
-            val imgArray = JSONArray(script.substringAfter("const images = ").substringBefore(";"))
-            if (imgArray != null) {
-                if (script.contains("bato.to/images")) {
-                    for (i in 0 until imgArray.length()) {
-                        val imgUrl = imgArray.get(i)
-                        pages.add(Page(i, "", "$imgUrl"))
-                    }
-                } else {
-                    for (i in 0 until imgArray.length()) {
-                        val imgUrl = imgArray.get(i)
-                        if (server.startsWith("http"))
-                            pages.add(Page(i, "", "${server}$imgUrl"))
-                        else
-                            pages.add(Page(i, "", "https:${server}$imgUrl"))
+            json.parseToJsonElement(script.substringAfter("const images = ").substringBefore(";")).jsonArray
+                .forEachIndexed { i, it ->
+                    val imgUrl = it.jsonPrimitive.content
+                    if (script.contains("bato.to/images")) {
+                        pages.add(Page(i, imageUrl = imgUrl))
+                    } else {
+                        pages.add(Page(i, imageUrl = if (server.startsWith("http")) "${server}$imgUrl" else "https:${server}$imgUrl"))
                     }
                 }
-            }
         }
 
         return pages
@@ -346,7 +334,7 @@ open class BatoTo(
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException("Not used")
 
     override fun getFilterList() = FilterList(
-        //LetterFilter(),
+        // LetterFilter(),
         Filter.Header("NOTE: Ignored if using text search!"),
         Filter.Separator(),
         SortFilter(getSortFilter(), 5),
@@ -367,10 +355,12 @@ open class BatoTo(
         val selected: String
             get() = options[state].value
     }
+
     abstract class CheckboxGroupFilter(name: String, options: List<CheckboxFilterOption>) : Filter.Group<CheckboxFilterOption>(name, options) {
         val selected: List<String>
             get() = state.filter { it.state }.map { it.value }
     }
+
     abstract class TriStateGroupFilter(name: String, options: List<TriStateFilterOption>) : Filter.Group<TriStateFilterOption>(name, options) {
         val included: List<String>
             get() = state.filter { it.isIncluded() }.map { it.value }
@@ -378,6 +368,7 @@ open class BatoTo(
         val excluded: List<String>
             get() = state.filter { it.isExcluded() }.map { it.value }
     }
+
     abstract class TextFilter(name: String) : Filter.Text(name)
 
     class SortFilter(options: List<SelectFilterOption>, default: Int) : SelectFilter("Sort By", options, default)
@@ -413,216 +404,216 @@ open class BatoTo(
 
     private fun getOrginFilter() = listOf(
         // Values exported from publish.bato.to
-        CheckboxFilterOption("zh","Chinese"),
-        CheckboxFilterOption("en","English"),
-        CheckboxFilterOption("ja","Japanese"),
-        CheckboxFilterOption("ko","Korean"),
-        CheckboxFilterOption("af","Afrikaans"),
-        CheckboxFilterOption("sq","Albanian"),
-        CheckboxFilterOption("am","Amharic"),
-        CheckboxFilterOption("ar","Arabic"),
-        CheckboxFilterOption("hy","Armenian"),
-        CheckboxFilterOption("az","Azerbaijani"),
-        CheckboxFilterOption("be","Belarusian"),
-        CheckboxFilterOption("bn","Bengali"),
-        CheckboxFilterOption("bs","Bosnian"),
-        CheckboxFilterOption("bg","Bulgarian"),
-        CheckboxFilterOption("my","Burmese"),
-        CheckboxFilterOption("km","Cambodian"),
-        CheckboxFilterOption("ca","Catalan"),
-        CheckboxFilterOption("ceb","Cebuano"),
-        CheckboxFilterOption("zh_hk","Chinese (Cantonese)"),
-        CheckboxFilterOption("zh_tw","Chinese (Traditional)"),
-        CheckboxFilterOption("hr","Croatian"),
-        CheckboxFilterOption("cs","Czech"),
-        CheckboxFilterOption("da","Danish"),
-        CheckboxFilterOption("nl","Dutch"),
-        CheckboxFilterOption("en_us","English (United States)"),
-        CheckboxFilterOption("eo","Esperanto"),
-        CheckboxFilterOption("et","Estonian"),
-        CheckboxFilterOption("fo","Faroese"),
-        CheckboxFilterOption("fil","Filipino"),
-        CheckboxFilterOption("fi","Finnish"),
-        CheckboxFilterOption("fr","French"),
-        CheckboxFilterOption("ka","Georgian"),
-        CheckboxFilterOption("de","German"),
-        CheckboxFilterOption("el","Greek"),
-        CheckboxFilterOption("gn","Guarani"),
-        CheckboxFilterOption("gu","Gujarati"),
-        CheckboxFilterOption("ht","Haitian Creole"),
-        CheckboxFilterOption("ha","Hausa"),
-        CheckboxFilterOption("he","Hebrew"),
-        CheckboxFilterOption("hi","Hindi"),
-        CheckboxFilterOption("hu","Hungarian"),
-        CheckboxFilterOption("is","Icelandic"),
-        CheckboxFilterOption("ig","Igbo"),
-        CheckboxFilterOption("id","Indonesian"),
-        CheckboxFilterOption("ga","Irish"),
-        CheckboxFilterOption("it","Italian"),
-        CheckboxFilterOption("jv","Javanese"),
-        CheckboxFilterOption("kn","Kannada"),
-        CheckboxFilterOption("kk","Kazakh"),
-        CheckboxFilterOption("ku","Kurdish"),
-        CheckboxFilterOption("ky","Kyrgyz"),
-        CheckboxFilterOption("lo","Laothian"),
-        CheckboxFilterOption("lv","Latvian"),
-        CheckboxFilterOption("lt","Lithuanian"),
-        CheckboxFilterOption("lb","Luxembourgish"),
-        CheckboxFilterOption("mk","Macedonian"),
-        CheckboxFilterOption("mg","Malagasy"),
-        CheckboxFilterOption("ms","Malay"),
-        CheckboxFilterOption("ml","Malayalam"),
-        CheckboxFilterOption("mt","Maltese"),
-        CheckboxFilterOption("mi","Maori"),
-        CheckboxFilterOption("mr","Marathi"),
-        CheckboxFilterOption("mo","Moldavian"),
-        CheckboxFilterOption("mn","Mongolian"),
-        CheckboxFilterOption("ne","Nepali"),
-        CheckboxFilterOption("no","Norwegian"),
-        CheckboxFilterOption("ny","Nyanja"),
-        CheckboxFilterOption("ps","Pashto"),
-        CheckboxFilterOption("fa","Persian"),
-        CheckboxFilterOption("pl","Polish"),
-        CheckboxFilterOption("pt","Portuguese"),
-        CheckboxFilterOption("pt_br","Portuguese (Brazil)"),
-        CheckboxFilterOption("ro","Romanian"),
-        CheckboxFilterOption("rm","Romansh"),
-        CheckboxFilterOption("ru","Russian"),
-        CheckboxFilterOption("sm","Samoan"),
-        CheckboxFilterOption("sr","Serbian"),
-        CheckboxFilterOption("sh","Serbo-Croatian"),
-        CheckboxFilterOption("st","Sesotho"),
-        CheckboxFilterOption("sn","Shona"),
-        CheckboxFilterOption("sd","Sindhi"),
-        CheckboxFilterOption("si","Sinhalese"),
-        CheckboxFilterOption("sk","Slovak"),
-        CheckboxFilterOption("sl","Slovenian"),
-        CheckboxFilterOption("so","Somali"),
-        CheckboxFilterOption("es","Spanish"),
-        CheckboxFilterOption("es_419","Spanish (Latin America)"),
-        CheckboxFilterOption("sw","Swahili"),
-        CheckboxFilterOption("sv","Swedish"),
-        CheckboxFilterOption("tg","Tajik"),
-        CheckboxFilterOption("ta","Tamil"),
-        CheckboxFilterOption("th","Thai"),
-        CheckboxFilterOption("ti","Tigrinya"),
-        CheckboxFilterOption("to","Tonga"),
-        CheckboxFilterOption("tr","Turkish"),
-        CheckboxFilterOption("tk","Turkmen"),
-        CheckboxFilterOption("uk","Ukrainian"),
-        CheckboxFilterOption("ur","Urdu"),
-        CheckboxFilterOption("uz","Uzbek"),
-        CheckboxFilterOption("vi","Vietnamese"),
-        CheckboxFilterOption("yo","Yoruba"),
-        CheckboxFilterOption("zu","Zulu"),
-        CheckboxFilterOption("_t","Other"),
+        CheckboxFilterOption("zh", "Chinese"),
+        CheckboxFilterOption("en", "English"),
+        CheckboxFilterOption("ja", "Japanese"),
+        CheckboxFilterOption("ko", "Korean"),
+        CheckboxFilterOption("af", "Afrikaans"),
+        CheckboxFilterOption("sq", "Albanian"),
+        CheckboxFilterOption("am", "Amharic"),
+        CheckboxFilterOption("ar", "Arabic"),
+        CheckboxFilterOption("hy", "Armenian"),
+        CheckboxFilterOption("az", "Azerbaijani"),
+        CheckboxFilterOption("be", "Belarusian"),
+        CheckboxFilterOption("bn", "Bengali"),
+        CheckboxFilterOption("bs", "Bosnian"),
+        CheckboxFilterOption("bg", "Bulgarian"),
+        CheckboxFilterOption("my", "Burmese"),
+        CheckboxFilterOption("km", "Cambodian"),
+        CheckboxFilterOption("ca", "Catalan"),
+        CheckboxFilterOption("ceb", "Cebuano"),
+        CheckboxFilterOption("zh_hk", "Chinese (Cantonese)"),
+        CheckboxFilterOption("zh_tw", "Chinese (Traditional)"),
+        CheckboxFilterOption("hr", "Croatian"),
+        CheckboxFilterOption("cs", "Czech"),
+        CheckboxFilterOption("da", "Danish"),
+        CheckboxFilterOption("nl", "Dutch"),
+        CheckboxFilterOption("en_us", "English (United States)"),
+        CheckboxFilterOption("eo", "Esperanto"),
+        CheckboxFilterOption("et", "Estonian"),
+        CheckboxFilterOption("fo", "Faroese"),
+        CheckboxFilterOption("fil", "Filipino"),
+        CheckboxFilterOption("fi", "Finnish"),
+        CheckboxFilterOption("fr", "French"),
+        CheckboxFilterOption("ka", "Georgian"),
+        CheckboxFilterOption("de", "German"),
+        CheckboxFilterOption("el", "Greek"),
+        CheckboxFilterOption("gn", "Guarani"),
+        CheckboxFilterOption("gu", "Gujarati"),
+        CheckboxFilterOption("ht", "Haitian Creole"),
+        CheckboxFilterOption("ha", "Hausa"),
+        CheckboxFilterOption("he", "Hebrew"),
+        CheckboxFilterOption("hi", "Hindi"),
+        CheckboxFilterOption("hu", "Hungarian"),
+        CheckboxFilterOption("is", "Icelandic"),
+        CheckboxFilterOption("ig", "Igbo"),
+        CheckboxFilterOption("id", "Indonesian"),
+        CheckboxFilterOption("ga", "Irish"),
+        CheckboxFilterOption("it", "Italian"),
+        CheckboxFilterOption("jv", "Javanese"),
+        CheckboxFilterOption("kn", "Kannada"),
+        CheckboxFilterOption("kk", "Kazakh"),
+        CheckboxFilterOption("ku", "Kurdish"),
+        CheckboxFilterOption("ky", "Kyrgyz"),
+        CheckboxFilterOption("lo", "Laothian"),
+        CheckboxFilterOption("lv", "Latvian"),
+        CheckboxFilterOption("lt", "Lithuanian"),
+        CheckboxFilterOption("lb", "Luxembourgish"),
+        CheckboxFilterOption("mk", "Macedonian"),
+        CheckboxFilterOption("mg", "Malagasy"),
+        CheckboxFilterOption("ms", "Malay"),
+        CheckboxFilterOption("ml", "Malayalam"),
+        CheckboxFilterOption("mt", "Maltese"),
+        CheckboxFilterOption("mi", "Maori"),
+        CheckboxFilterOption("mr", "Marathi"),
+        CheckboxFilterOption("mo", "Moldavian"),
+        CheckboxFilterOption("mn", "Mongolian"),
+        CheckboxFilterOption("ne", "Nepali"),
+        CheckboxFilterOption("no", "Norwegian"),
+        CheckboxFilterOption("ny", "Nyanja"),
+        CheckboxFilterOption("ps", "Pashto"),
+        CheckboxFilterOption("fa", "Persian"),
+        CheckboxFilterOption("pl", "Polish"),
+        CheckboxFilterOption("pt", "Portuguese"),
+        CheckboxFilterOption("pt_br", "Portuguese (Brazil)"),
+        CheckboxFilterOption("ro", "Romanian"),
+        CheckboxFilterOption("rm", "Romansh"),
+        CheckboxFilterOption("ru", "Russian"),
+        CheckboxFilterOption("sm", "Samoan"),
+        CheckboxFilterOption("sr", "Serbian"),
+        CheckboxFilterOption("sh", "Serbo-Croatian"),
+        CheckboxFilterOption("st", "Sesotho"),
+        CheckboxFilterOption("sn", "Shona"),
+        CheckboxFilterOption("sd", "Sindhi"),
+        CheckboxFilterOption("si", "Sinhalese"),
+        CheckboxFilterOption("sk", "Slovak"),
+        CheckboxFilterOption("sl", "Slovenian"),
+        CheckboxFilterOption("so", "Somali"),
+        CheckboxFilterOption("es", "Spanish"),
+        CheckboxFilterOption("es_419", "Spanish (Latin America)"),
+        CheckboxFilterOption("sw", "Swahili"),
+        CheckboxFilterOption("sv", "Swedish"),
+        CheckboxFilterOption("tg", "Tajik"),
+        CheckboxFilterOption("ta", "Tamil"),
+        CheckboxFilterOption("th", "Thai"),
+        CheckboxFilterOption("ti", "Tigrinya"),
+        CheckboxFilterOption("to", "Tonga"),
+        CheckboxFilterOption("tr", "Turkish"),
+        CheckboxFilterOption("tk", "Turkmen"),
+        CheckboxFilterOption("uk", "Ukrainian"),
+        CheckboxFilterOption("ur", "Urdu"),
+        CheckboxFilterOption("uz", "Uzbek"),
+        CheckboxFilterOption("vi", "Vietnamese"),
+        CheckboxFilterOption("yo", "Yoruba"),
+        CheckboxFilterOption("zu", "Zulu"),
+        CheckboxFilterOption("_t", "Other"),
     )
 
     private fun getGenreFilter() = listOf(
-        TriStateFilterOption("artbook","Artbook"),
-        TriStateFilterOption("cartoon","Cartoon"),
-        TriStateFilterOption("comic","Comic"),
-        TriStateFilterOption("doujinshi","Doujinshi"),
-        TriStateFilterOption("imageset","Imageset"),
-        TriStateFilterOption("manga","Manga"),
-        TriStateFilterOption("manhua","Manhua"),
-        TriStateFilterOption("manhwa","Manhwa"),
-        TriStateFilterOption("webtoon","Webtoon"),
-        TriStateFilterOption("western","Western"),
-        TriStateFilterOption("josei","Josei"),
-        TriStateFilterOption("seinen","Seinen"),
-        TriStateFilterOption("shoujo","Shoujo"),
-        TriStateFilterOption("shoujo_ai","Shoujo ai"),
-        TriStateFilterOption("shounen","Shounen"),
-        TriStateFilterOption("shounen_ai","Shounen ai"),
-        TriStateFilterOption("yaoi","Yaoi"),
-        TriStateFilterOption("yuri","Yuri"),
-        TriStateFilterOption("ecchi","Ecchi"),
-        TriStateFilterOption("mature","Mature"),
-        TriStateFilterOption("adult","Adult"),
-        TriStateFilterOption("gore","Gore"),
-        TriStateFilterOption("violence","Violence"),
-        TriStateFilterOption("smut","Smut"),
-        TriStateFilterOption("hentai","Hentai"),
-        TriStateFilterOption("_4_koma","4-Koma"),
-        TriStateFilterOption("action","Action"),
-        TriStateFilterOption("adaptation","Adaptation"),
-        TriStateFilterOption("adventure","Adventure"),
-        TriStateFilterOption("aliens","Aliens"),
-        TriStateFilterOption("animals","Animals"),
-        TriStateFilterOption("anthology","Anthology"),
-        TriStateFilterOption("cars","cars"),
-        TriStateFilterOption("comedy","Comedy"),
-        TriStateFilterOption("cooking","Cooking"),
-        TriStateFilterOption("crime","crime"),
-        TriStateFilterOption("crossdressing","Crossdressing"),
-        TriStateFilterOption("delinquents","Delinquents"),
-        TriStateFilterOption("dementia","Dementia"),
-        TriStateFilterOption("demons","Demons"),
-        TriStateFilterOption("drama","Drama"),
-        TriStateFilterOption("fantasy","Fantasy"),
-        TriStateFilterOption("fan_colored","Fan-Colored"),
-        TriStateFilterOption("full_color","Full Color"),
-        TriStateFilterOption("game","Game"),
-        TriStateFilterOption("gender_bender","Gender Bender"),
-        TriStateFilterOption("genderswap","Genderswap"),
-        TriStateFilterOption("ghosts","Ghosts"),
-        TriStateFilterOption("gyaru","Gyaru"),
-        TriStateFilterOption("harem","Harem"),
-        TriStateFilterOption("harlequin","Harlequin"),
-        TriStateFilterOption("historical","Historical"),
-        TriStateFilterOption("horror","Horror"),
-        TriStateFilterOption("incest","Incest"),
-        TriStateFilterOption("isekai","Isekai"),
-        TriStateFilterOption("kids","Kids"),
-        TriStateFilterOption("loli","Loli"),
-        TriStateFilterOption("lolicon","lolicon"),
-        TriStateFilterOption("magic","Magic"),
-        TriStateFilterOption("magical_girls","Magical Girls"),
-        TriStateFilterOption("martial_arts","Martial Arts"),
-        TriStateFilterOption("mecha","Mecha"),
-        TriStateFilterOption("medical","Medical"),
-        TriStateFilterOption("military","Military"),
-        TriStateFilterOption("monster_girls","Monster Girls"),
-        TriStateFilterOption("monsters","Monsters"),
-        TriStateFilterOption("music","Music"),
-        TriStateFilterOption("mystery","Mystery"),
-        TriStateFilterOption("netorare","Netorare/NTR"),
-        TriStateFilterOption("ninja","Ninja"),
-        TriStateFilterOption("office_workers","Office Workers"),
-        TriStateFilterOption("oneshot","Oneshot"),
-        TriStateFilterOption("parody","parody"),
-        TriStateFilterOption("philosophical","Philosophical"),
-        TriStateFilterOption("police","Police"),
-        TriStateFilterOption("post_apocalyptic","Post-Apocalyptic"),
-        TriStateFilterOption("psychological","Psychological"),
-        TriStateFilterOption("reincarnation","Reincarnation"),
-        TriStateFilterOption("reverse_harem","Reverse Harem"),
-        TriStateFilterOption("romance","Romance"),
-        TriStateFilterOption("samurai","Samurai"),
-        TriStateFilterOption("school_life","School Life"),
-        TriStateFilterOption("sci_fi","Sci-Fi"),
-        TriStateFilterOption("shota","Shota"),
-        TriStateFilterOption("shotacon","shotacon"),
-        TriStateFilterOption("slice_of_life","Slice of Life"),
-        TriStateFilterOption("sm_bdsm","SM/BDSM"),
-        TriStateFilterOption("space","Space"),
-        TriStateFilterOption("sports","Sports"),
-        TriStateFilterOption("super_power","Super Power"),
-        TriStateFilterOption("superhero","Superhero"),
-        TriStateFilterOption("supernatural","Supernatural"),
-        TriStateFilterOption("survival","Survival"),
-        TriStateFilterOption("thriller","Thriller"),
-        TriStateFilterOption("time_travel","Time Travel"),
-        TriStateFilterOption("traditional_games","Traditional Games"),
-        TriStateFilterOption("tragedy","Tragedy"),
-        TriStateFilterOption("vampires","Vampires"),
-        TriStateFilterOption("video_games","Video Games"),
-        TriStateFilterOption("virtual_reality","Virtual Reality"),
-        TriStateFilterOption("wuxia","Wuxia"),
-        TriStateFilterOption("xianxia","Xianxia"),
-        TriStateFilterOption("xuanhuan","Xuanhuan"),
-        TriStateFilterOption("zombies","Zombies"),
+        TriStateFilterOption("artbook", "Artbook"),
+        TriStateFilterOption("cartoon", "Cartoon"),
+        TriStateFilterOption("comic", "Comic"),
+        TriStateFilterOption("doujinshi", "Doujinshi"),
+        TriStateFilterOption("imageset", "Imageset"),
+        TriStateFilterOption("manga", "Manga"),
+        TriStateFilterOption("manhua", "Manhua"),
+        TriStateFilterOption("manhwa", "Manhwa"),
+        TriStateFilterOption("webtoon", "Webtoon"),
+        TriStateFilterOption("western", "Western"),
+        TriStateFilterOption("josei", "Josei"),
+        TriStateFilterOption("seinen", "Seinen"),
+        TriStateFilterOption("shoujo", "Shoujo"),
+        TriStateFilterOption("shoujo_ai", "Shoujo ai"),
+        TriStateFilterOption("shounen", "Shounen"),
+        TriStateFilterOption("shounen_ai", "Shounen ai"),
+        TriStateFilterOption("yaoi", "Yaoi"),
+        TriStateFilterOption("yuri", "Yuri"),
+        TriStateFilterOption("ecchi", "Ecchi"),
+        TriStateFilterOption("mature", "Mature"),
+        TriStateFilterOption("adult", "Adult"),
+        TriStateFilterOption("gore", "Gore"),
+        TriStateFilterOption("violence", "Violence"),
+        TriStateFilterOption("smut", "Smut"),
+        TriStateFilterOption("hentai", "Hentai"),
+        TriStateFilterOption("_4_koma", "4-Koma"),
+        TriStateFilterOption("action", "Action"),
+        TriStateFilterOption("adaptation", "Adaptation"),
+        TriStateFilterOption("adventure", "Adventure"),
+        TriStateFilterOption("aliens", "Aliens"),
+        TriStateFilterOption("animals", "Animals"),
+        TriStateFilterOption("anthology", "Anthology"),
+        TriStateFilterOption("cars", "cars"),
+        TriStateFilterOption("comedy", "Comedy"),
+        TriStateFilterOption("cooking", "Cooking"),
+        TriStateFilterOption("crime", "crime"),
+        TriStateFilterOption("crossdressing", "Crossdressing"),
+        TriStateFilterOption("delinquents", "Delinquents"),
+        TriStateFilterOption("dementia", "Dementia"),
+        TriStateFilterOption("demons", "Demons"),
+        TriStateFilterOption("drama", "Drama"),
+        TriStateFilterOption("fantasy", "Fantasy"),
+        TriStateFilterOption("fan_colored", "Fan-Colored"),
+        TriStateFilterOption("full_color", "Full Color"),
+        TriStateFilterOption("game", "Game"),
+        TriStateFilterOption("gender_bender", "Gender Bender"),
+        TriStateFilterOption("genderswap", "Genderswap"),
+        TriStateFilterOption("ghosts", "Ghosts"),
+        TriStateFilterOption("gyaru", "Gyaru"),
+        TriStateFilterOption("harem", "Harem"),
+        TriStateFilterOption("harlequin", "Harlequin"),
+        TriStateFilterOption("historical", "Historical"),
+        TriStateFilterOption("horror", "Horror"),
+        TriStateFilterOption("incest", "Incest"),
+        TriStateFilterOption("isekai", "Isekai"),
+        TriStateFilterOption("kids", "Kids"),
+        TriStateFilterOption("loli", "Loli"),
+        TriStateFilterOption("lolicon", "lolicon"),
+        TriStateFilterOption("magic", "Magic"),
+        TriStateFilterOption("magical_girls", "Magical Girls"),
+        TriStateFilterOption("martial_arts", "Martial Arts"),
+        TriStateFilterOption("mecha", "Mecha"),
+        TriStateFilterOption("medical", "Medical"),
+        TriStateFilterOption("military", "Military"),
+        TriStateFilterOption("monster_girls", "Monster Girls"),
+        TriStateFilterOption("monsters", "Monsters"),
+        TriStateFilterOption("music", "Music"),
+        TriStateFilterOption("mystery", "Mystery"),
+        TriStateFilterOption("netorare", "Netorare/NTR"),
+        TriStateFilterOption("ninja", "Ninja"),
+        TriStateFilterOption("office_workers", "Office Workers"),
+        TriStateFilterOption("oneshot", "Oneshot"),
+        TriStateFilterOption("parody", "parody"),
+        TriStateFilterOption("philosophical", "Philosophical"),
+        TriStateFilterOption("police", "Police"),
+        TriStateFilterOption("post_apocalyptic", "Post-Apocalyptic"),
+        TriStateFilterOption("psychological", "Psychological"),
+        TriStateFilterOption("reincarnation", "Reincarnation"),
+        TriStateFilterOption("reverse_harem", "Reverse Harem"),
+        TriStateFilterOption("romance", "Romance"),
+        TriStateFilterOption("samurai", "Samurai"),
+        TriStateFilterOption("school_life", "School Life"),
+        TriStateFilterOption("sci_fi", "Sci-Fi"),
+        TriStateFilterOption("shota", "Shota"),
+        TriStateFilterOption("shotacon", "shotacon"),
+        TriStateFilterOption("slice_of_life", "Slice of Life"),
+        TriStateFilterOption("sm_bdsm", "SM/BDSM"),
+        TriStateFilterOption("space", "Space"),
+        TriStateFilterOption("sports", "Sports"),
+        TriStateFilterOption("super_power", "Super Power"),
+        TriStateFilterOption("superhero", "Superhero"),
+        TriStateFilterOption("supernatural", "Supernatural"),
+        TriStateFilterOption("survival", "Survival"),
+        TriStateFilterOption("thriller", "Thriller"),
+        TriStateFilterOption("time_travel", "Time Travel"),
+        TriStateFilterOption("traditional_games", "Traditional Games"),
+        TriStateFilterOption("tragedy", "Tragedy"),
+        TriStateFilterOption("vampires", "Vampires"),
+        TriStateFilterOption("video_games", "Video Games"),
+        TriStateFilterOption("virtual_reality", "Virtual Reality"),
+        TriStateFilterOption("wuxia", "Wuxia"),
+        TriStateFilterOption("xianxia", "Xianxia"),
+        TriStateFilterOption("xuanhuan", "Xuanhuan"),
+        TriStateFilterOption("zombies", "Zombies"),
         // Hidden Genres
         TriStateFilterOption("award_winning", "Award Winning"),
         TriStateFilterOption("youkai", "Youkai"),
@@ -631,112 +622,112 @@ open class BatoTo(
 
     private fun getLangFilter() = listOf(
         // Values exported from publish.bato.to
-        CheckboxFilterOption("en","English"),
-        CheckboxFilterOption("ar","Arabic"),
-        CheckboxFilterOption("bg","Bulgarian"),
-        CheckboxFilterOption("zh","Chinese"),
-        CheckboxFilterOption("cs","Czech"),
-        CheckboxFilterOption("da","Danish"),
-        CheckboxFilterOption("nl","Dutch"),
-        CheckboxFilterOption("fil","Filipino"),
-        CheckboxFilterOption("fi","Finnish"),
-        CheckboxFilterOption("fr","French"),
-        CheckboxFilterOption("de","German"),
-        CheckboxFilterOption("el","Greek"),
-        CheckboxFilterOption("he","Hebrew"),
-        CheckboxFilterOption("hi","Hindi"),
-        CheckboxFilterOption("hu","Hungarian"),
-        CheckboxFilterOption("id","Indonesian"),
-        CheckboxFilterOption("it","Italian"),
-        CheckboxFilterOption("ja","Japanese"),
-        CheckboxFilterOption("ko","Korean"),
-        CheckboxFilterOption("ms","Malay"),
-        CheckboxFilterOption("pl","Polish"),
-        CheckboxFilterOption("pt","Portuguese"),
-        CheckboxFilterOption("pt_br","Portuguese (Brazil)"),
-        CheckboxFilterOption("ro","Romanian"),
-        CheckboxFilterOption("ru","Russian"),
-        CheckboxFilterOption("es","Spanish"),
-        CheckboxFilterOption("es_419","Spanish (Latin America)"),
-        CheckboxFilterOption("sv","Swedish"),
-        CheckboxFilterOption("th","Thai"),
-        CheckboxFilterOption("tr","Turkish"),
-        CheckboxFilterOption("uk","Ukrainian"),
-        CheckboxFilterOption("vi","Vietnamese"),
-        CheckboxFilterOption("af","Afrikaans"),
-        CheckboxFilterOption("sq","Albanian"),
-        CheckboxFilterOption("am","Amharic"),
-        CheckboxFilterOption("hy","Armenian"),
-        CheckboxFilterOption("az","Azerbaijani"),
-        CheckboxFilterOption("be","Belarusian"),
-        CheckboxFilterOption("bn","Bengali"),
-        CheckboxFilterOption("bs","Bosnian"),
-        CheckboxFilterOption("my","Burmese"),
-        CheckboxFilterOption("km","Cambodian"),
-        CheckboxFilterOption("ca","Catalan"),
-        CheckboxFilterOption("ceb","Cebuano"),
-        CheckboxFilterOption("zh_hk","Chinese (Cantonese)"),
-        CheckboxFilterOption("zh_tw","Chinese (Traditional)"),
-        CheckboxFilterOption("hr","Croatian"),
-        CheckboxFilterOption("en_us","English (United States)"),
-        CheckboxFilterOption("eo","Esperanto"),
-        CheckboxFilterOption("et","Estonian"),
-        CheckboxFilterOption("fo","Faroese"),
-        CheckboxFilterOption("ka","Georgian"),
-        CheckboxFilterOption("gn","Guarani"),
-        CheckboxFilterOption("gu","Gujarati"),
-        CheckboxFilterOption("ht","Haitian Creole"),
-        CheckboxFilterOption("ha","Hausa"),
-        CheckboxFilterOption("is","Icelandic"),
-        CheckboxFilterOption("ig","Igbo"),
-        CheckboxFilterOption("ga","Irish"),
-        CheckboxFilterOption("jv","Javanese"),
-        CheckboxFilterOption("kn","Kannada"),
-        CheckboxFilterOption("kk","Kazakh"),
-        CheckboxFilterOption("ku","Kurdish"),
-        CheckboxFilterOption("ky","Kyrgyz"),
-        CheckboxFilterOption("lo","Laothian"),
-        CheckboxFilterOption("lv","Latvian"),
-        CheckboxFilterOption("lt","Lithuanian"),
-        CheckboxFilterOption("lb","Luxembourgish"),
-        CheckboxFilterOption("mk","Macedonian"),
-        CheckboxFilterOption("mg","Malagasy"),
-        CheckboxFilterOption("ml","Malayalam"),
-        CheckboxFilterOption("mt","Maltese"),
-        CheckboxFilterOption("mi","Maori"),
-        CheckboxFilterOption("mr","Marathi"),
-        CheckboxFilterOption("mo","Moldavian"),
-        CheckboxFilterOption("mn","Mongolian"),
-        CheckboxFilterOption("ne","Nepali"),
-        CheckboxFilterOption("no","Norwegian"),
-        CheckboxFilterOption("ny","Nyanja"),
-        CheckboxFilterOption("ps","Pashto"),
-        CheckboxFilterOption("fa","Persian"),
-        CheckboxFilterOption("rm","Romansh"),
-        CheckboxFilterOption("sm","Samoan"),
-        CheckboxFilterOption("sr","Serbian"),
-        CheckboxFilterOption("sh","Serbo-Croatian"),
-        CheckboxFilterOption("st","Sesotho"),
-        CheckboxFilterOption("sn","Shona"),
-        CheckboxFilterOption("sd","Sindhi"),
-        CheckboxFilterOption("si","Sinhalese"),
-        CheckboxFilterOption("sk","Slovak"),
-        CheckboxFilterOption("sl","Slovenian"),
-        CheckboxFilterOption("so","Somali"),
-        CheckboxFilterOption("sw","Swahili"),
-        CheckboxFilterOption("tg","Tajik"),
-        CheckboxFilterOption("ta","Tamil"),
-        CheckboxFilterOption("ti","Tigrinya"),
-        CheckboxFilterOption("to","Tonga"),
-        CheckboxFilterOption("tk","Turkmen"),
-        CheckboxFilterOption("ur","Urdu"),
-        CheckboxFilterOption("uz","Uzbek"),
-        CheckboxFilterOption("yo","Yoruba"),
-        CheckboxFilterOption("zu","Zulu"),
-        CheckboxFilterOption("_t","Other"),
+        CheckboxFilterOption("en", "English"),
+        CheckboxFilterOption("ar", "Arabic"),
+        CheckboxFilterOption("bg", "Bulgarian"),
+        CheckboxFilterOption("zh", "Chinese"),
+        CheckboxFilterOption("cs", "Czech"),
+        CheckboxFilterOption("da", "Danish"),
+        CheckboxFilterOption("nl", "Dutch"),
+        CheckboxFilterOption("fil", "Filipino"),
+        CheckboxFilterOption("fi", "Finnish"),
+        CheckboxFilterOption("fr", "French"),
+        CheckboxFilterOption("de", "German"),
+        CheckboxFilterOption("el", "Greek"),
+        CheckboxFilterOption("he", "Hebrew"),
+        CheckboxFilterOption("hi", "Hindi"),
+        CheckboxFilterOption("hu", "Hungarian"),
+        CheckboxFilterOption("id", "Indonesian"),
+        CheckboxFilterOption("it", "Italian"),
+        CheckboxFilterOption("ja", "Japanese"),
+        CheckboxFilterOption("ko", "Korean"),
+        CheckboxFilterOption("ms", "Malay"),
+        CheckboxFilterOption("pl", "Polish"),
+        CheckboxFilterOption("pt", "Portuguese"),
+        CheckboxFilterOption("pt_br", "Portuguese (Brazil)"),
+        CheckboxFilterOption("ro", "Romanian"),
+        CheckboxFilterOption("ru", "Russian"),
+        CheckboxFilterOption("es", "Spanish"),
+        CheckboxFilterOption("es_419", "Spanish (Latin America)"),
+        CheckboxFilterOption("sv", "Swedish"),
+        CheckboxFilterOption("th", "Thai"),
+        CheckboxFilterOption("tr", "Turkish"),
+        CheckboxFilterOption("uk", "Ukrainian"),
+        CheckboxFilterOption("vi", "Vietnamese"),
+        CheckboxFilterOption("af", "Afrikaans"),
+        CheckboxFilterOption("sq", "Albanian"),
+        CheckboxFilterOption("am", "Amharic"),
+        CheckboxFilterOption("hy", "Armenian"),
+        CheckboxFilterOption("az", "Azerbaijani"),
+        CheckboxFilterOption("be", "Belarusian"),
+        CheckboxFilterOption("bn", "Bengali"),
+        CheckboxFilterOption("bs", "Bosnian"),
+        CheckboxFilterOption("my", "Burmese"),
+        CheckboxFilterOption("km", "Cambodian"),
+        CheckboxFilterOption("ca", "Catalan"),
+        CheckboxFilterOption("ceb", "Cebuano"),
+        CheckboxFilterOption("zh_hk", "Chinese (Cantonese)"),
+        CheckboxFilterOption("zh_tw", "Chinese (Traditional)"),
+        CheckboxFilterOption("hr", "Croatian"),
+        CheckboxFilterOption("en_us", "English (United States)"),
+        CheckboxFilterOption("eo", "Esperanto"),
+        CheckboxFilterOption("et", "Estonian"),
+        CheckboxFilterOption("fo", "Faroese"),
+        CheckboxFilterOption("ka", "Georgian"),
+        CheckboxFilterOption("gn", "Guarani"),
+        CheckboxFilterOption("gu", "Gujarati"),
+        CheckboxFilterOption("ht", "Haitian Creole"),
+        CheckboxFilterOption("ha", "Hausa"),
+        CheckboxFilterOption("is", "Icelandic"),
+        CheckboxFilterOption("ig", "Igbo"),
+        CheckboxFilterOption("ga", "Irish"),
+        CheckboxFilterOption("jv", "Javanese"),
+        CheckboxFilterOption("kn", "Kannada"),
+        CheckboxFilterOption("kk", "Kazakh"),
+        CheckboxFilterOption("ku", "Kurdish"),
+        CheckboxFilterOption("ky", "Kyrgyz"),
+        CheckboxFilterOption("lo", "Laothian"),
+        CheckboxFilterOption("lv", "Latvian"),
+        CheckboxFilterOption("lt", "Lithuanian"),
+        CheckboxFilterOption("lb", "Luxembourgish"),
+        CheckboxFilterOption("mk", "Macedonian"),
+        CheckboxFilterOption("mg", "Malagasy"),
+        CheckboxFilterOption("ml", "Malayalam"),
+        CheckboxFilterOption("mt", "Maltese"),
+        CheckboxFilterOption("mi", "Maori"),
+        CheckboxFilterOption("mr", "Marathi"),
+        CheckboxFilterOption("mo", "Moldavian"),
+        CheckboxFilterOption("mn", "Mongolian"),
+        CheckboxFilterOption("ne", "Nepali"),
+        CheckboxFilterOption("no", "Norwegian"),
+        CheckboxFilterOption("ny", "Nyanja"),
+        CheckboxFilterOption("ps", "Pashto"),
+        CheckboxFilterOption("fa", "Persian"),
+        CheckboxFilterOption("rm", "Romansh"),
+        CheckboxFilterOption("sm", "Samoan"),
+        CheckboxFilterOption("sr", "Serbian"),
+        CheckboxFilterOption("sh", "Serbo-Croatian"),
+        CheckboxFilterOption("st", "Sesotho"),
+        CheckboxFilterOption("sn", "Shona"),
+        CheckboxFilterOption("sd", "Sindhi"),
+        CheckboxFilterOption("si", "Sinhalese"),
+        CheckboxFilterOption("sk", "Slovak"),
+        CheckboxFilterOption("sl", "Slovenian"),
+        CheckboxFilterOption("so", "Somali"),
+        CheckboxFilterOption("sw", "Swahili"),
+        CheckboxFilterOption("tg", "Tajik"),
+        CheckboxFilterOption("ta", "Tamil"),
+        CheckboxFilterOption("ti", "Tigrinya"),
+        CheckboxFilterOption("to", "Tonga"),
+        CheckboxFilterOption("tk", "Turkmen"),
+        CheckboxFilterOption("ur", "Urdu"),
+        CheckboxFilterOption("uz", "Uzbek"),
+        CheckboxFilterOption("yo", "Yoruba"),
+        CheckboxFilterOption("zu", "Zulu"),
+        CheckboxFilterOption("_t", "Other"),
         // Lang options from bato.to brows not in publish.bato.to
         CheckboxFilterOption("eu", "Basque"),
-        CheckboxFilterOption("pt-PT","Portuguese (Portugal)"),
+        CheckboxFilterOption("pt-PT", "Portuguese (Portugal)"),
     ).filterNot { it.value == siteLang }
 
     private inline fun <reified T> Iterable<*>.findInstance() = find { it is T } as? T

--- a/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
+++ b/src/all/batoto/src/eu/kanade/tachiyomi/extension/all/batoto/BatoTo.kt
@@ -298,8 +298,14 @@ open class BatoTo(
         val script = document.select("script").html()
 
         if (script.contains("var images =")) {
-            val imgJson = json.parseToJsonElement(script.substringAfter("var images = ").substringBefore(";")).jsonObject
-            imgJson.keys.forEachIndexed { i, s -> pages.add(Page(i, imageUrl = imgJson[s]!!.jsonPrimitive.content)) }
+            /*
+             * During kotlinx.serialization migration, the pre-existing code seemed to not work
+             * Could not find a case where code would run in practice, so it was commented out.
+             */
+            throw RuntimeException("Unexpected Branch: Please File A Bug Report describing this issue")
+            // val imgJson = json.parseToJsonElement(script.substringAfter("var images = ").substringBefore(";")).jsonObject
+            // imgJson.keys.forEachIndexed { i, s -> pages.add(Page(i, imageUrl = imgJson[s]!!.jsonPrimitive.content)) }
+
         } else if (script.contains("const server =")) { // bato.to
             val duktape = Duktape.create()
             val encryptedServer = script.substringAfter("const server = ").substringBefore(";")

--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'Dynasty'
     pkgNameSuffix = 'en.dynasty'
     extClass = '.DynastyFactory'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScans.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyScans.kt
@@ -10,15 +10,19 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Request
 import okhttp3.Response
-import org.json.JSONArray
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import org.jsoup.select.Elements
 import rx.Observable
+import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.ArrayList
 import java.util.Locale
@@ -42,6 +46,8 @@ abstract class DynastyScans : ParsedHttpSource() {
     private var imgList = InternalList(ArrayList(), "")
 
     private var _valid: Validate = Validate(false, -1)
+
+    private val json: Json by injectLazy()
 
     override fun popularMangaRequest(page: Int): Request {
         return GET(popularMangaInitialUrl(), headers)
@@ -189,19 +195,16 @@ abstract class DynastyScans : ParsedHttpSource() {
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        val pages = mutableListOf<Page>()
-        try {
+        return try {
             val imageUrl = document.select("script").last().html().substringAfter("var pages = [").substringBefore("];")
-            val imageUrls = JSONArray("[$imageUrl]")
 
-            (0 until imageUrls.length())
-                .map { imageUrls.getJSONObject(it) }
-                .map { baseUrl + it.get("image") }
-                .forEach { pages.add(Page(pages.size, "", it)) }
+            json.parseToJsonElement("[$imageUrl]").jsonArray.mapIndexed { index, it ->
+                Page(index, imageUrl = "$baseUrl${it.jsonObject["image"]!!.jsonPrimitive.content}")
+            }
         } catch (e: Exception) {
             e.printStackTrace()
+            emptyList()
         }
-        return pages
     }
 
     class InternalList(nodes: List<Node>, type: String) : ArrayList<String>() {

--- a/src/en/mangapark/build.gradle
+++ b/src/en/mangapark/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'MangaPark'
     pkgNameSuffix = 'en.mangapark'
     extClass = '.MangaPark'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/en/readm/build.gradle
+++ b/src/en/readm/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'ReadM'
     pkgNameSuffix = 'en.readm'
     extClass = '.ReadM'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
This pull request supports #7392, replacing the used json library with kotlinx.serialization

- [x] en.MangaPark 
- [x] BatoTo.kt
- [x] DynastyScans.kt
- [x] ReadM.kt
