### PR TITLE
[Hitomi.la] Remove hardcode image path condition

### DIFF
--- a/src/all/hitomi/build.gradle
+++ b/src/all/hitomi/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Hitomi.la'
     pkgNameSuffix = 'all.hitomi'
     extClass = '.HitomiFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
     containsNsfw = true
 }


### PR DESCRIPTION
[FIX] Remove hardcode image path condition

Rather than hardcoded conditions for determining image path's first subdomain,
the extension now dynamically load the condition by parsing the condition from
Hitomi.la's common.js. This should keep the cat and mouse chase a little bit longer.

[REFACTOR] Simplify regular expression for id extraction