### PR TITLE
Fix only one page of MangaMiso filter results being returned

### DIFF
--- a/src/en/mangamiso/build.gradle
+++ b/src/en/mangamiso/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MangaMiso'
     pkgNameSuffix = 'en.mangamiso'
     extClass = '.MangaMiso'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/en/mangamiso/src/eu/kanade/tachiyomi/extension/en/mangamiso/MangaMiso.kt
+++ b/src/en/mangamiso/src/eu/kanade/tachiyomi/extension/en/mangamiso/MangaMiso.kt
@@ -115,7 +115,7 @@ class MangaMiso : HttpSource() {
             val mangaList = json.decodeFromString<MisoBrowseManga>(response.body!!.string())
             val page = response.request.url.queryParameter("page")!!.toInt()
             val totalViewedManga = page * MANGA_PER_PAGE
-            MangasPage(mangaList.foundList.map(::toSManga), mangaList.totalResults > totalViewedManga)
+            MangasPage(mangaList.foundList.map(::toSManga), mangaList.total > totalViewedManga)
         }
     }
 

--- a/src/en/mangamiso/src/eu/kanade/tachiyomi/extension/en/mangamiso/MangaMisoObjects.kt
+++ b/src/en/mangamiso/src/eu/kanade/tachiyomi/extension/en/mangamiso/MangaMisoObjects.kt
@@ -18,7 +18,7 @@ data class MisoLatestUpdatesPage(
 @Serializable
 data class MisoBrowseManga(
     val foundList: List<MisoManga> = emptyList(),
-    val totalResults: Int = 0
+    val total: Int = 0
 )
 
 @Serializable


### PR DESCRIPTION
I think MangaMiso slightly changed their internal API, as the name of one of the fields returned when doing a filter search originally was `totalResults`, but now it's just `total`.
I think that's the case, I hope I just didn't manage to miss testing that when initially creating the extension ¯\\\_(ツ)_/¯

This change meant that when filtering manga, only 1 page of results would be viewable.

This PR corrects the field name, so that multiple pages of results are returned when doing a search via Filters