### PR TITLE
[zh-dmzj] Make ChapterOrder field optional

### DIFF
--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Dmzj'
     pkgNameSuffix = 'zh.dmzj'
     extClass = '.Dmzj'
-    extVersionCode = 23
+    extVersionCode = 24
     libVersion = '1.2'
 }
 

--- a/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/protobuf/V4apiComicDetailResponse.kt
+++ b/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/protobuf/V4apiComicDetailResponse.kt
@@ -62,5 +62,5 @@ data class ComicDetailChapterInfoResponse(
     @ProtoNumber(2) val ChapterTitle: String,
     @ProtoNumber(3) val Updatetime: Long,
     @ProtoNumber(4) val Filesize: Int,
-    @ProtoNumber(5) val ChapterOrder: Int,
+    @ProtoNumber(5) val ChapterOrder: Int = 0,
 )


### PR DESCRIPTION
`ChapterOrder` field of `ComicDetailChapterInfoResponse` may be missing in valid response, and is actually not used by the extension. Make it optional by specifying a default value.

The manga I tested with is: https://m.dmzj.com/info/49093.html

<details><summary>LogCat output when I'm investigationg why manga that are reabable on website still fallback</summary>

```
2021-06-28 23:36:03.210 20307-4819/? E/dmzj: v4api chapter list failed
    kotlinx.serialization.MissingFieldException: Field 'ChapterOrder' is required for type with serial name 'eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterInfoResponse', but it was missing
        at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:3)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterInfoResponse.<init>(Unknown Source:14)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterInfoResponse$$serializer.deserialize(Unknown Source:137)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterInfoResponse$$serializer.deserialize(V4apiComicDetailResponse.kt:60)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:7)
        at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeSerializableElement(ProtobufTaggedDecoder.kt:3)
        at kotlinx.serialization.encoding.CompositeDecoder$DefaultImpls.decodeSerializableElement$default(Decoding.kt:1)
        at kotlinx.serialization.internal.ListLikeSerializer.readElement(CollectionSerializers.kt:1)
        at kotlinx.serialization.internal.AbstractCollectionSerializer.readElement$default(CollectionSerializers.kt:1)
        at kotlinx.serialization.internal.AbstractCollectionSerializer.merge(CollectionSerializers.kt:9)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:6)
        at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeSerializableElement(ProtobufTaggedDecoder.kt:3)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterResponse$$serializer.deserialize(Unknown Source:70)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailChapterResponse$$serializer.deserialize(V4apiComicDetailResponse.kt:54)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:7)
        at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeSerializableElement(ProtobufTaggedDecoder.kt:3)
        at kotlinx.serialization.encoding.CompositeDecoder$DefaultImpls.decodeSerializableElement$default(Decoding.kt:1)
        at kotlinx.serialization.internal.ListLikeSerializer.readElement(CollectionSerializers.kt:1)
        at kotlinx.serialization.internal.AbstractCollectionSerializer.readElement$default(CollectionSerializers.kt:1)
        at kotlinx.serialization.internal.AbstractCollectionSerializer.merge(CollectionSerializers.kt:9)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:6)
        at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeSerializableElement(ProtobufTaggedDecoder.kt:3)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailInfoResponse$$serializer.deserialize(Unknown Source:516)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailInfoResponse$$serializer.deserialize(V4apiComicDetailResponse.kt:19)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:7)
        at kotlinx.serialization.protobuf.internal.ProtobufTaggedDecoder.decodeSerializableElement(ProtobufTaggedDecoder.kt:3)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailResponse$$serializer.deserialize(Unknown Source:69)
        at eu.kanade.tachiyomi.extension.zh.dmzj.protobuf.ComicDetailResponse$$serializer.deserialize(V4apiComicDetailResponse.kt:12)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:7)
        at kotlinx.serialization.protobuf.internal.ProtobufDecoder.decodeSerializableValue(ProtobufDecoding.kt:1)
        at kotlinx.serialization.protobuf.ProtoBuf.decodeFromByteArray(ProtoBuf.kt:3)
        at eu.kanade.tachiyomi.extension.zh.dmzj.Dmzj.chapterListParse(Dmzj.kt:626)
        at eu.kanade.tachiyomi.extension.zh.dmzj.Dmzj.fetchChapterList(Dmzj.kt:309)
        at eu.kanade.tachiyomi.source.Source$DefaultImpls.getChapterList(Source.kt:4)
```

</details>