### PR TITLE
[WPMangaReader, WPMangaStream] Prevent pages that don't have abs:src from being added to page list

### DIFF
--- a/multisrc/overrides/wpmangastream/komikstation/src/KomikStation.kt
+++ b/multisrc/overrides/wpmangastream/komikstation/src/KomikStation.kt
@@ -28,7 +28,7 @@ class KomikStation : WPMangaStream("Komik Station", "https://komikstation.com", 
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         document.select(pageSelector)
-            .filterNot { it.attr("src").isNullOrEmpty() }
+            .filterNot { it.attr("abs:src").isNullOrEmpty() }
             .mapIndexed { i, img -> pages.add(Page(i, "", img.attr("abs:src"))) }
 
         // Some sites like mangakita now load pages via javascript

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReader.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReader.kt
@@ -240,7 +240,7 @@ abstract class WPMangaReader(
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         document.select(pageSelector)
-            .filterNot { it.attr("src").isNullOrEmpty() }
+            .filterNot { it.attr("abs:src").isNullOrEmpty() }
             .mapIndexed { i, img -> pages.add(Page(i, "", img.attr("abs:src"))) }
 
         // Some sites like mangakita now load pages via javascript

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangareader/WPMangaReaderGenerator.kt
@@ -9,7 +9,7 @@ class WPMangaReaderGenerator : ThemeSourceGenerator {
 
     override val themeClass = "WPMangaReader"
 
-    override val baseVersionCode: Int = 7
+    override val baseVersionCode: Int = 8
 
     override val sources = listOf(
         SingleLang("Kiryuu", "https://kiryuu.id", "id", overrideVersionCode = 1),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStream.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStream.kt
@@ -275,7 +275,7 @@ abstract class WPMangaStream(
 
     override fun pageListParse(document: Document): List<Page> {
         val htmlPages = document.select(pageSelector)
-            .filterNot { it.attr("src").isNullOrEmpty() }
+            .filterNot { it.attr("abs:src").isNullOrEmpty() }
             .mapIndexed { i, img -> Page(i, "", img.attr("abs:src")) }
             .toMutableList()
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
@@ -9,7 +9,7 @@ class WPMangaStreamGenerator : ThemeSourceGenerator {
 
     override val themeClass = "WPMangaStream"
 
-    override val baseVersionCode: Int = 6
+    override val baseVersionCode: Int = 7
 
     override val sources = listOf(
             SingleLang("Asura Scans", "https://www.asurascans.com", "en", overrideVersionCode = 1),


### PR DESCRIPTION
In a few cases, 'src' would be a literal SVG (a loading icon) rather than a URL to the page's image, which would work fine with 'src' but show up as an empty string for 'abs:src'.

xCaliBR was one such source. In its case, it would load the page list as a single empty page, instead of the correct page URLs, and would prevent the js-page-detection logic from populating the actual page list.

Tested xCaliBR, Komik Station, APairOf2 (as samples of each of the multisrc's that changed).
