### PR TITLE
Add title text as a page to Swords Comic source

### DIFF
--- a/src/en/swordscomic/build.gradle
+++ b/src/en/swordscomic/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Swords Comic'
     pkgNameSuffix = 'en.swordscomic'
     extClass = '.SwordsComic'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/swordscomic/src/eu/kanade/tachiyomi/extension/en/swordscomic/SwordsComic.kt
+++ b/src/en/swordscomic/src/eu/kanade/tachiyomi/extension/en/swordscomic/SwordsComic.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.swordscomic
 
+import android.net.Uri
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -87,7 +88,25 @@ class SwordsComic : HttpSource() {
     // Pages
 
     override fun pageListParse(response: Response): List<Page> {
-        return listOf(Page(0, "", response.asJsoup().select("img#comic-image").attr("abs:src")))
+        val imageElement = response.asJsoup().select("img#comic-image")
+        if (!imageElement.hasAttr("title")) {
+            return listOf(Page(0, "", imageElement.attr("abs:src")))
+        }
+
+        val builder = StringBuilder()
+        var charCount = 0
+
+        for (word in imageElement.attr("title").splitToSequence(" ")) {
+            if (charCount + word.length > 45) {
+                builder.append("%0A")
+                charCount = 0
+            }
+            charCount += word.length + 1
+            builder.append(Uri.encode(word.toUpperCase()))
+            builder.append("+")
+        }
+
+        return listOf(Page(0, "", imageElement.attr("abs:src")), Page(1, "", "https://fakeimg.pl/1800x2252/978B65/000000/?text=$builder&font_size=60&font=comic+sans"))
     }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException("Not used")


### PR DESCRIPTION
Adds title text as a page to chapters in the Swords Comic source, similar to the current behavior of the xkcd source. 

Example of a generated title text page (from Swords DXI):
![Swords Comic - DXI - Nothing to Fear - 2](https://user-images.githubusercontent.com/34069872/124946792-4e56a600-dfdd-11eb-9e0b-580da0bc3e2c.png)
