### PR TITLE
Make MangaDex load images more consistently

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 123
+    extVersionCode = 124
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -106,6 +106,12 @@ class MangaDexHelper() {
     // chapter url where we get the token, last request time
     private val tokenTracker = hashMapOf<String, Long>()
 
+    companion object {
+        val USE_CACHE = CacheControl.Builder()
+            .maxStale(Integer.MAX_VALUE, TimeUnit.SECONDS)
+            .build()
+    }
+
     // Check the token map to see if the md@home host is still valid
     fun getValidImageUrlForPage(page: Page, headers: Headers, client: OkHttpClient): Request {
         val data = page.url.split(",")
@@ -123,7 +129,7 @@ class MangaDexHelper() {
                         ) {
                             CacheControl.FORCE_NETWORK
                         } else {
-                            CacheControl.FORCE_CACHE
+                            USE_CACHE
                         }
                     getMdAtHomeUrl(tokenRequestUrl, client, headers, cacheControl)
                 }
@@ -145,6 +151,14 @@ class MangaDexHelper() {
         }
         val response =
             client.newCall(GET(tokenRequestUrl, headers, cacheControl)).execute()
+
+        // This check is for the error that causes pages to fail to load.
+        // It should never be entered, but in case it is, we retry the request.
+        if (response.code == 504) {
+            Log.wtf("MangaDex", "Failed to read cache for \"$tokenRequestUrl\"")
+            return getMdAtHomeUrl(tokenRequestUrl, client, headers, CacheControl.FORCE_NETWORK)
+        }
+
         return json.decodeFromString<AtHomeDto>(response.body!!.string()).baseUrl
     }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -19,6 +19,7 @@ import okhttp3.Request
 import org.jsoup.parser.Parser
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 class MangaDexHelper() {
 


### PR DESCRIPTION
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
Being that this pull request has no issues to close, I will explain what the problem is.

After 5 mins, chapters being read from the MangaDex extension would fail to load images. This happened because after 5 mins, the extension would try to make sure the MD@H url was still correct.

But what would happen is that the cache wouldn't end up having the url in it, and would report a `504 Unsatisfiable Request` with an empty body. This would lead to the url to the image being incorrect. Why the cache would start dropping the data, I don't know.

This pull request does 2 things.
1) Don't force cache access if we know that the MD@H url should be valid.
2) If we end up with getting `504 Unsatisfiable Request`, retry and force a network request so that we can cache it.
