### PR TITLE
[Komga] filter deleted series and books

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.29
+
+Minimum Komga version required: `0.97.0`
+
+### Features
+
+* filter deleted series and books
+
 ## 1.2.28
 
 Minimum Komga version required: `0.97.0`

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 28
+    extVersionCode = 29
     libVersion = '1.2'
 }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -43,13 +43,13 @@ import java.util.Locale
 
 open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
     override fun popularMangaRequest(page: Int): Request =
-        GET("$baseUrl/api/v1/series?page=${page - 1}", headers)
+        GET("$baseUrl/api/v1/series?page=${page - 1}&deleted=false", headers)
 
     override fun popularMangaParse(response: Response): MangasPage =
         processSeriesPage(response)
 
     override fun latestUpdatesRequest(page: Int): Request =
-        GET("$baseUrl/api/v1/series/latest?page=${page - 1}", headers)
+        GET("$baseUrl/api/v1/series/latest?page=${page - 1}&deleted=false", headers)
 
     override fun latestUpdatesParse(response: Response): MangasPage =
         processSeriesPage(response)
@@ -65,7 +65,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
             else -> "series"
         }
 
-        val url = "$baseUrl/api/v1/$type?search=$query&page=${page - 1}".toHttpUrlOrNull()!!.newBuilder()
+        val url = "$baseUrl/api/v1/$type?search=$query&page=${page - 1}&deleted=false".toHttpUrlOrNull()!!.newBuilder()
 
         filters.forEach { filter ->
             when (filter) {
@@ -185,7 +185,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, HttpSource() {
         }
 
     override fun chapterListRequest(manga: SManga): Request =
-        GET("${manga.url}/books?unpaged=true&media_status=READY", headers)
+        GET("${manga.url}/books?unpaged=true&media_status=READY&deleted=false", headers)
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val page = gson.fromJson<PageWrapperDto<BookDto>>(response.body?.charStream()!!).content


### PR DESCRIPTION
This is a backward compatible change to prepare for the new version of Komga that will fix https://github.com/gotson/komga/issues/217

Books and series can appear as `Unavailable` when the files are not present anymore (like Plex). This version of the extension will filter out all those deleted series and books.