### PR TITLE
Cubari release_date fix + volume null fix

### DIFF
--- a/src/all/cubari/build.gradle
+++ b/src/all/cubari/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Cubari'
     pkgNameSuffix = "all.cubari"
     extClass = '.CubariFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -277,7 +277,7 @@ open class Cubari(override val lang: String) : HttpSource() {
                     scanlator = groups[groupNum]!!.jsonPrimitive.content
                     chapter_number = chapterNum.toFloatOrNull() ?: -1f
 
-                    if (chapterObj["release_date"]!!.jsonObject[groupNum] != null) {
+                    if (chapterObj["release_date"]?.jsonObject?.get(groupNum) != null) {
                         val temp = chapterObj["release_date"]!!.jsonObject[groupNum]!!.jsonPrimitive.double
                         date_upload = temp.toLong() * 1000
                     } else {

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -255,6 +255,8 @@ open class Cubari(override val lang: String) : HttpSource() {
 
     // ------------- Helpers and whatnot ---------------
 
+    private val volumeNotSpecifiedTerms = setOf("Uncategorized", "null")
+
     private fun parseChapterList(payload: String, manga: SManga): List<SChapter> {
         val jsonObj = json.parseToJsonElement(payload).jsonObject
         val groups = jsonObj["groups"]!!.jsonObject
@@ -268,18 +270,21 @@ open class Cubari(override val lang: String) : HttpSource() {
             val chapterNum = chapterEntry.key
             val chapterObj = chapterEntry.value.jsonObject
             val chapterGroups = chapterObj["groups"]!!.jsonObject
-            val volume = chapterObj["volume"]!!.jsonPrimitive.content
+            val volume = chapterObj["volume"]!!.jsonPrimitive.content.let {
+                if (volumeNotSpecifiedTerms.contains(it)) null else it
+            }
+            val title = chapterObj["title"]!!.jsonPrimitive.content
 
             chapterGroups.entries.map { groupEntry ->
                 val groupNum = groupEntry.key
+                val releaseDate = chapterObj["release_date"]?.jsonObject?.get(groupNum)
 
                 SChapter.create().apply {
                     scanlator = groups[groupNum]!!.jsonPrimitive.content
                     chapter_number = chapterNum.toFloatOrNull() ?: -1f
 
-                    if (chapterObj["release_date"]?.jsonObject?.get(groupNum) != null) {
-                        val temp = chapterObj["release_date"]!!.jsonObject[groupNum]!!.jsonPrimitive.double
-                        date_upload = temp.toLong() * 1000
+                    if (releaseDate != null) {
+                        date_upload = releaseDate.jsonPrimitive.double.toLong() * 1000
                     } else {
                         val currentTimeMillis = System.currentTimeMillis()
 
@@ -290,13 +295,12 @@ open class Cubari(override val lang: String) : HttpSource() {
                         date_upload = seriesPrefs.getLong(chapterNum, currentTimeMillis)
                     }
 
-                    name = if (volume.isNotEmpty() && volume != "Uncategorized") {
+                    name = if (volume != null) {
                         // Output "Vol. 1 Ch. 1 - Chapter Name"
-                        "Vol. " + chapterObj["volume"]!!.jsonPrimitive.content + " Ch. " +
-                            chapterNum + " - " + chapterObj["title"]!!.jsonPrimitive.content
+                        "Vol. $volume Ch. $chapterNum - $title"
                     } else {
                         // Output "Ch. 1 - Chapter Name"
-                        "Ch. " + chapterNum + " - " + chapterObj["title"]!!.jsonPrimitive.content
+                        "Ch. $chapterNum - $title"
                     }
 
                     url = if (chapterGroups[groupNum] is JsonArray) {


### PR DESCRIPTION
Got recently changed with  #8126, altering it to make it Cubari Imgur source compatible.

Cubari API responses don't contain release_date information when the Cubari source is Imgur.
The minor change made with this commit makes the existence of the release_date json property for the parsing process optional.

Tested with https://cubari.moe/read/imgur/fE52z40/ as well as the Cubari Mangadex and Cubari Gist sources from the PR mentioned above.

Edit:
This PR now also contains a fix for when the volume in the json is set to null (won't be included in the chapter name anymore).
Was a problem e.g. with https://cubari.moe/read/mangadex/e83c326b-921b-45ff-bc0c-d667bbfe64cc/
Also cleaned up the chapter title concatenation (had some duplicate code for chapter names with and without volume numbers).