### PR TITLE
Inspect extensions to get source information

### DIFF
--- a/.github/scripts/create-repo.sh
+++ b/.github/scripts/create-repo.sh
@@ -30,6 +30,8 @@ for APK in ${APKS[@]}; do
     ICON=$(echo "$BADGING" | grep -Po "application-icon-320.*'\K[^']+")
     unzip -p $APK $ICON > icon/${FILENAME%.*}.png
 
+    SOURCE_INFO=$(jq ".[\"$PKGNAME\"]" < ../output.json)
+
     jq -n \
         --arg name "$LABEL" \
         --arg pkg "$PKGNAME" \
@@ -38,7 +40,8 @@ for APK in ${APKS[@]}; do
         --argjson code $VCODE \
         --arg version "$VNAME" \
         --argjson nsfw $NSFW \
-        '{name:$name, pkg:$pkg, apk:$apk, lang:$lang, code:$code, version:$version, nsfw:$nsfw}'
+        --argjson sources "$SOURCE_INFO" \
+        '{name:$name, pkg:$pkg, apk:$apk, lang:$lang, code:$code, version:$version, nsfw:$nsfw, sources:$sources}'
 
 done | jq -sr '[.[]]' > index.json
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -128,6 +128,11 @@ jobs:
           ref: master
           path: master
 
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Sign APKs
         run: |
           cd master
@@ -136,6 +141,11 @@ jobs:
             ${{ secrets.ALIAS }} \
             ${{ secrets.KEY_STORE_PASSWORD }} \
             ${{ secrets.KEY_PASSWORD }}
+
+      - name: Run inspector
+        run: |
+          cd master
+          java -jar ./.github/runner-files/Inspector.jar "apk" "output.json" "tmp"
 
       - name: Create repo artifacts
         run: |

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Run inspector
         run: |
           cd master
-          INSPECTOR_LINK="$(curl -s "https://api.github.com/repos/tachiyomiorg/tachiyomi-extensions-inspector/releases/latest" | grep -o "https.*download\/[a-zA-Z0-9.\/-]*")"
+          INSPECTOR_LINK="$(curl -s "https://api.github.com/repos/tachiyomiorg/tachiyomi-extensions-inspector/releases/latest" | jq -r '.assets[0].browser_download_url')"
           curl -L "$INSPECTOR_LINK" -o ./Inspector.jar
           java -jar ./Inspector.jar "apk" "output.json" "tmp"
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Sign APKs
         run: |

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Run inspector
         run: |
           cd master
-          java -jar ./.github/runner-files/Inspector.jar "apk" "output.json" "tmp"
+          INSPECTOR_LINK="$(curl -s "https://api.github.com/repos/tachiyomiorg/tachiyomi-extensions-inspector/releases/latest" | grep -o "https.*download\/[a-zA-Z0-9.\/-]*")"
+          curl -L "$INSPECTOR_LINK" -o ./Inspector.jar
+          java -jar ./Inspector.jar "apk" "output.json" "tmp"
 
       - name: Create repo artifacts
         run: |


### PR DESCRIPTION
Continues #6410


This is an rewritten version of the Tachidesk Inspector that ArMor PR'd back in April. It takes the suggestions of other contributors, such as:

- Puts the array of source information(such as name, lang, and id) inside the index.json as a item in the extensions object. 
- Deletes all Tachidesk specific code, only adding whats needed for the Inspector
- Puts the Inspector.jar in the runner-files so that it is not downloaded externally

Sample from index.json
```json
[
  {
    "name": "Tachiyomi: Cubari",
    "pkg": "eu.kanade.tachiyomi.extension.all.cubari",
    "apk": "tachiyomi-all.cubari-v1.2.9.apk",
    "lang": "all",
    "code": 9,
    "version": "1.2.9",
    "nsfw": 0,
    "sources": [
      {
        "name": "Cubari",
        "lang": "en",
        "id": 6338219619148106000
      },
      {
        "name": "Cubari",
        "lang": "all",
        "id": 1470847599087460400
      },
      {
        "name": "Cubari",
        "lang": "other",
        "id": 2013845246758512400
      }
    ]
  },
  ...
]
```

Successful build of the index.json:
https://github.com/Syer10/tachiyomi-extensions/blob/repo/index.json

Successful run for the Inspector.jar:
https://github.com/Syer10/tachiyomi-extensions/actions/runs/1061635114
The Inspector.jar only takes around 30 seconds to go over around 1000 extensions.

Repo for the Inspector.jar:
https://github.com/Syer10/TachiExtension-Inspector
This can be transferred to the organization