### PR TITLE
CopyManga: Fix missing decrypt password

### DIFF
--- a/src/zh/copymanga/build.gradle
+++ b/src/zh/copymanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'CopyManga'
     pkgNameSuffix = 'zh.copymanga'
     extClass = '.CopyManga'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 apply from: "$rootDir/common.gradle"
 

--- a/src/zh/copymanga/src/eu/kanade/tachiyomi/extension/zh/copymanga/CopyManga.kt
+++ b/src/zh/copymanga/src/eu/kanade/tachiyomi/extension/zh/copymanga/CopyManga.kt
@@ -449,10 +449,10 @@ class CopyManga : ConfigurableSource, HttpSource() {
     }
 
     // thanks to unpacker toolsite, http://matthewfl.com/unPacker.html
-    private fun decryptChapterData(disposableData: String, disposablePass: String? = "hotmanga.aes.key"): String {
+    private fun decryptChapterData(disposableData: String, disposablePass: String?): String {
         val prePart = disposableData.substring(0, 16)
         val postPart = disposableData.substring(16, disposableData.length)
-        val disposablePassByteArray = disposablePass?.toByteArray(Charsets.UTF_8)
+        val disposablePassByteArray = (disposablePass ?: "xxxmanga.abc.key").toByteArray(Charsets.UTF_8)
         val prepartByteArray = prePart.toByteArray(Charsets.UTF_8)
         val dataByteArray = hexStringToByteArray(postPart)
 


### PR DESCRIPTION
When we end up with a decrypt password of null (that is, there is no comic-specific decryption password), fall back to the default password. Previously, we ended up passing in null instead of a default password.

Also update the default password.

Fixes #9114

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Annotated `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- [x] Added the `containsNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `versionId` if a source's name or language were changed
