### PR TITLE
NicovideoSeiga: Fix file type handling.

### DIFF
--- a/src/ja/nicovideoseiga/build.gradle
+++ b/src/ja/nicovideoseiga/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Nicovideo Seiga'
     pkgNameSuffix = 'ja.nicovideoseiga'
     extClass = '.NicovideoSeiga'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
+++ b/src/ja/nicovideoseiga/src/eu/kanade/tachiyomi/extension/ja/nicovideoseiga/NicovideoSeiga.kt
@@ -238,8 +238,7 @@ class NicovideoSeiga : HttpSource() {
         val decryptedImage = decryptImage(key, encryptedImage)
 
         // Construct a new response
-        val contentType = response.header("Content-Type", "image/${getImageType(decryptedImage)}")
-        val body = decryptedImage.toResponseBody(contentType!!.toMediaTypeOrNull())
+        val body = decryptedImage.toResponseBody("image/${getImageType(decryptedImage)}".toMediaTypeOrNull())
         return response.newBuilder().body(body).build()
     }
 
@@ -272,11 +271,11 @@ class NicovideoSeiga : HttpSource() {
      * This is also how Nicovideo does it
      */
     private fun getImageType(image: ByteArray): String {
-        return if (image[0].toInt() == 0xff && image[1].toInt() == 0xd8 && image[image.size - 2].toInt() == 0xff && image[image.size - 1].toInt() == 0xd9) {
+        return if (image[0].toInt() == -1 && image[1].toInt() == -40 && image[image.size - 2].toInt() == -1 && image[image.size - 1].toInt() == -39) {
             "jpeg"
-        } else if (image[0].toInt() == 0x89 && image[1].toInt() == 0x50 && image[2].toInt() == 0x4e && image[3].toInt() == 0x47) {
+        } else if (image[0].toInt() == -119 && image[1].toInt() == 80 && image[2].toInt() == 78 && image[3].toInt() == 71) {
             "png"
-        } else if (image[0].toInt() == 0x47 && image[1].toInt() == 0x49 && image[2].toInt() == 0x46 && image[3].toInt() == 0x38) {
+        } else if (image[0].toInt() == 71 && image[1].toInt() == 73 && image[2].toInt() == 70 && image[3].toInt() == 56) {
             "gif"
         } else {
             // It defaults to null in the site, but it's a webp image


### PR DESCRIPTION
When downloading NicovideoSeiga image, the saved file extension has become wrong type. This commit addresses the issue by fixing following errors.
- Images is determined the type by file header. The logic has wrongly assumed Byte.toInt() returns unsigned integer, but it actually returns signed value.
- The server returns application/octet-stream as Content-Type header. But the logic only worked when header is empty.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
