### PR TITLE
Infernal Void Scans: Fix page parsing

### DIFF
--- a/multisrc/overrides/wpmangastream/infernalvoidscans/src/InfernalVoidScans.kt
+++ b/multisrc/overrides/wpmangastream/infernalvoidscans/src/InfernalVoidScans.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.extension.en.infernalvoidscans
+
+import eu.kanade.tachiyomi.multisrc.wpmangastream.WPMangaStream
+import eu.kanade.tachiyomi.source.model.Page
+import org.jsoup.nodes.Document
+
+class InfernalVoidScans : WPMangaStream("Infernal Void Scans", "https://infernalvoidscans.com", "en") {
+    // Site dynamically replaces a placeholder image in the "src" tag with the actual url in "data-src"
+    override fun pageListParse(document: Document): List<Page> {
+        return super.pageListParse(
+            document.apply {
+                select(pageSelector).forEach { pageElem ->
+                    pageElem.attr("data-src")
+                        .takeIf { ! it.isNullOrBlank() }
+                        ?.let { pageElem.attr("src", it) }
+                }
+            }
+        )
+    }
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
@@ -14,7 +14,7 @@ class WPMangaStreamGenerator : ThemeSourceGenerator {
 
     override val sources = listOf(
         MultiLang("Asura Scans", "https://www.asurascans.com", listOf("en", "tr"), className = "AsuraScansFactory", pkgName = "asurascans", overrideVersionCode = 10),
-        SingleLang("Infernal Void Scans", "https://infernalvoidscans.com", "en", overrideVersionCode = 2),
+        SingleLang("Infernal Void Scans", "https://infernalvoidscans.com", "en", overrideVersionCode = 3),
         SingleLang("KlanKomik", "https://klankomik.com", "id", overrideVersionCode = 1),
         SingleLang("Kombatch", "https://kombatch.com", "id"),
         SingleLang("MasterKomik", "https://masterkomik.com", "id", overrideVersionCode = 1),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
