### PR TITLE
BlogTruyen: Fix parse page list not return enough pages in some manga

### DIFF
--- a/src/vi/blogtruyen/build.gradle
+++ b/src/vi/blogtruyen/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'BlogTruyen'
     pkgNameSuffix = 'vi.blogtruyen'
     extClass = '.BlogTruyen'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/vi/blogtruyen/src/eu/kanade/tachiyomi/extension/vi/blogtruyen/BlogTruyen.kt
+++ b/src/vi/blogtruyen/src/eu/kanade/tachiyomi/extension/vi/blogtruyen/BlogTruyen.kt
@@ -14,6 +14,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import org.json.JSONArray
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -170,6 +171,18 @@ class BlogTruyen : ParsedHttpSource() {
         document.select("article#content > img").forEachIndexed { i, e ->
             pages.add(Page(i, pageUrl, e.attr("src")))
         }
+
+        // Some chapters use js script to render images
+        val script = document.select("article#content > script").lastOrNull()
+        if (script != null && script.data().contains("listImageCaption")) {
+            val imagesStr = script.data().split(";")[0].split("=").last().trim()
+            val imageArr = JSONArray(imagesStr)
+            for (i in 0 until imageArr.length()) {
+                val imageUrl = imageArr.getJSONObject(i).getString("url")
+                pages.add(Page(pages.size, pageUrl, imageUrl))
+            }
+        }
+
         return pages
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
