### PR TITLE
Genkan: Add support for determining series type

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/genkan/Genkan.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/genkan/Genkan.kt
@@ -96,13 +96,16 @@ open class Genkan(
             .let { if (it.startsWith("http")) it else baseUrl + it }
     }
 
-    override fun mangaDetailsParse(document: Document): SManga {
-        return SManga.create().apply {
-            title = document.select("div#content h5").first().text()
-            description = document.select("div.col-lg-9").text().substringAfter("Description ").substringBefore(" Volume")
-            thumbnail_url = styleToUrl(document.select("div.media a").first())
-        }
+    protected var countryOfOriginSelector = ".card.mt-2 .list-item:contains(Country of Origin) .no-wrap"
+    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+        title = document.select("div#content h5").first().text()
+        description = document.select("div.col-lg-9").text().substringAfter("Description ").substringBefore(" Volume")
+        thumbnail_url = styleToUrl(document.select("div.media a").first())
+        genre = listOfNotNull(
+            document.selectFirst(countryOfOriginSelector)?.let { countryOfOriginToSeriesType(it.text())}
+        ).joinToString()
     }
+
 
     override fun chapterListSelector() = "div.col-lg-9 div.flex"
 
@@ -135,6 +138,13 @@ open class Genkan(
         } else {
             dateFormat.parse(string)?.time ?: 0
         }
+    }
+
+    private fun countryOfOriginToSeriesType(country: String) = when (country) {
+        "South Korea" -> "Manhwa"
+        "Japan" -> "Manga"
+        "China" -> "Manhua"
+        else -> null
     }
 
     // Subtract relative date (e.g. posted 3 days ago)

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/genkan/GenkanGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/genkan/GenkanGenerator.kt
@@ -9,7 +9,7 @@ class GenkanGenerator : ThemeSourceGenerator {
 
     override val themeClass = "Genkan"
 
-    override val baseVersionCode: Int = 2
+    override val baseVersionCode: Int = 3
 
     override val sources = listOf(
         SingleLang("Hunlight Scans", "https://hunlight-scans.info", "en"),


### PR DESCRIPTION
This pull request adds support for parsing the series type (manhwa, manga, manhua) to Genkan multisrc extensions

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
