### PR TITLE
Replace Manga1000/1001 with Comick and MangaPro

### DIFF
--- a/src/ja/mangaraw/build.gradle
+++ b/src/ja/mangaraw/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaRaw'
     pkgNameSuffix = 'ja.mangaraw'
     extClass = '.MangaRawFactory'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/MangaRawFactory.kt
+++ b/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/MangaRawFactory.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.extension.ja.mangaraw
 
+import eu.kanade.tachiyomi.extension.ja.mangaraw.sources.Comick
+import eu.kanade.tachiyomi.extension.ja.mangaraw.sources.MangaPro
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 
@@ -9,12 +11,3 @@ class MangaRawFactory : SourceFactory {
         MangaPro()
     )
 }
-
-// Comick has a slightly different layout in html, even though it looks exactly the same to MangaRaw visually
-class Comick : MangaRaw(
-    "Comick",
-    "https://comick.top",
-    "#main > article > div > div > div.entry-content > center > p > img"
-)
-
-class MangaPro : MangaRaw("MangaPro", "https://mangapro.top")

--- a/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/MangaRawFactory.kt
+++ b/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/MangaRawFactory.kt
@@ -5,10 +5,16 @@ import eu.kanade.tachiyomi.source.SourceFactory
 
 class MangaRawFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
-        Manga1000(),
-        Manga1001()
+        Comick(),
+        MangaPro()
     )
 }
 
-class Manga1000 : MangaRaw("Manga1000", "https://manga1000.com")
-class Manga1001 : MangaRaw("Manga1001", "https://manga1001.com")
+// Comick has a slightly different layout in html, even though it looks exactly the same to MangaRaw visually
+class Comick : MangaRaw(
+    "Comick",
+    "https://comick.top",
+    "#main > article > div > div > div.entry-content > center > p > img"
+)
+
+class MangaPro : MangaRaw("MangaPro", "https://mangapro.top")

--- a/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/sources/Comick.kt
+++ b/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/sources/Comick.kt
@@ -1,0 +1,15 @@
+package eu.kanade.tachiyomi.extension.ja.mangaraw.sources
+
+import eu.kanade.tachiyomi.extension.ja.mangaraw.MangaRaw
+import okhttp3.Request
+
+// Comick has a slightly different layout in html, even though it looks exactly the same to MangaRaw visually
+class Comick : MangaRaw("Comick", "https://comick.top") {
+
+    override val imageSelector =
+        "#main > article > div > div > div.entry-content > center > p > img"
+
+    // comick.top doesn't have a popular manga page
+    // redirect to latest manga request
+    override fun popularMangaRequest(page: Int): Request = latestUpdatesRequest(page)
+}

--- a/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/sources/MangaPro.kt
+++ b/src/ja/mangaraw/src/eu/kanade/tachiyomi/extension/ja/mangaraw/sources/MangaPro.kt
@@ -1,0 +1,18 @@
+package eu.kanade.tachiyomi.extension.ja.mangaraw.sources
+
+import eu.kanade.tachiyomi.extension.ja.mangaraw.MangaRaw
+import eu.kanade.tachiyomi.source.model.SManga
+import org.jsoup.nodes.Document
+
+class MangaPro : MangaRaw("MangaPro", "https://mangapro.top") {
+    override fun mangaDetailsParse(document: Document) = SManga.create().apply {
+        // Extract the author, take out the colon and quotes
+        author = document.select("#main > article > div > div > div > div > p").html()
+            .substringAfter("</strong>").substringBefore("<br>").drop(1)
+        genre = document.select("#main > article > div > div > div > div > p > a")
+            .joinToString(separator = ", ", transform = { it.text() })
+        description = document.select("#main > article > div > div > div > div > p").html()
+            .substringAfterLast("<br>")
+        thumbnail_url = document.select(".wp-block-image img").attr("abs:src")
+    }
+}


### PR DESCRIPTION
Checklist:

Closes #11047 

Both Manga1000 and Manga1001 has been [DMCA'd and shut down by Shogakukan, Shueisha, Kadokawa and Kodansha](https://torrentfreak.com/major-manga-publishers-try-to-identify-operators-of-massive-pirate-sites-211211/). And judging from the news sources, Manga1002 might also soon be taken down. Plus it has a completely different layout from the old one. Not sure if it's even the same site, so I'm not going to spend time on that one.

comick.top and mangapro.top are the copycats (Not the same owner) of these two sites. They look the same visually but have slightly different html layout. It's also filled with clickjacking ads. **Highly not recommend viewing the site in WebView**

Users are required to migrate their library to the new sources.

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
