### PR TITLE
latisbooks: fix page loading

### DIFF
--- a/src/en/latisbooks/build.gradle
+++ b/src/en/latisbooks/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Latis Books'
     pkgNameSuffix = 'en.latisbooks'
     extClass = '.Latisbooks'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
+++ b/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
@@ -122,7 +122,7 @@ class Latisbooks : HttpSource() {
 
         // Handle multiple images per page (e.g. Page 23+24)
         val pages = blocks.select("img.thumb-image")
-            .mapIndexed { i, it -> Page(i, it.attr("abs:data-src")) }
+            .mapIndexed { i, it -> Page(i, "", it.attr("abs:data-src")) }
             .toMutableList()
 
         val numImages = pages.size
@@ -133,7 +133,7 @@ class Latisbooks : HttpSource() {
                 .map { it.select("div.sqs-block-content").first() }
                 // Some pages have empty html blocks (e.g. Page 1), so ignore them
                 .filter { it.childrenSize() > 0 }
-                .mapIndexed { i, it -> Page(i + numImages, wordWrap(it.text()).image()) }
+                .mapIndexed { i, it -> Page(i + numImages, "", wordWrap(it.text()).image()) }
                 .toList()
         )
 


### PR DESCRIPTION
my bad, I thought it worked without the extra strings, but I guess when
I tested it, the chapter cache was stale. Even with debugging tools,
Android is pain.

At least the comic only updates on Mondays and Fridays :d

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
	- [x] I have double and triple checked it this time, and made sure the chapter cache wasn't stale.
