### PR TITLE
Fix date and chapter name from ReaperScans EN

### DIFF
--- a/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
+++ b/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
@@ -21,27 +21,23 @@ abstract class ReaperScans(
     override val baseUrl: String,
     lang: String,
     dateFormat: SimpleDateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US)
-) : Madara("Reaper Scans", baseUrl, lang, dateFormat) {
+) : Madara("Reaper Scans", baseUrl, lang, dateFormat)
+
+class ReaperScansEn : ReaperScans("https://reaperscans.com", "en", SimpleDateFormat("MMM dd,yyyy", Locale.US)) {
 
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = SChapter.create()
-
         with(element) {
             select(chapterUrlSelector).first()?.let { urlElement ->
                 chapter.url = urlElement.attr("abs:href").let {
                     it.substringBefore("?style=paged") + if (!it.endsWith(chapterUrlSuffix)) chapterUrlSuffix else ""
                 }
-                chapter.name = urlElement.select("p.chapter-manhwa-title").firstOrNull()?.ownText().toString()
+                chapter.name = urlElement.select("p.chapter-manhwa-title").firstOrNull()?.text().toString()
             }
-            chapter.date_upload = select("span.chapter-release-date i").firstOrNull()?.text().let { parseChapterDate(it) }
+            chapter.date_upload = select("span.chapter-release-date > i").firstOrNull()?.text().let { parseChapterDate(it) }
         }
-
         return chapter
     }
-}
-
-class ReaperScansEn : ReaperScans("https://reaperscans.com", "en") {
-    override val versionId = 2
 }
 
 class ReaperScansBr : ReaperScans("https://reaperscans.com.br", "pt-BR", SimpleDateFormat("dd/MM/yyyy", Locale.US)) {

--- a/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
+++ b/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
@@ -24,6 +24,7 @@ abstract class ReaperScans(
 ) : Madara("Reaper Scans", baseUrl, lang, dateFormat)
 
 class ReaperScansEn : ReaperScans("https://reaperscans.com", "en", SimpleDateFormat("MMM dd,yyyy", Locale.US)) {
+    override val versionId = 2
 
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = SChapter.create()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -16,7 +16,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         MultiLang("Leviatan Scans", "https://leviatanscans.com", listOf("en", "es"), className = "LeviatanScansFactory", overrideVersionCode = 9),
         MultiLang("MangaForFree.net", "https://mangaforfree.net", listOf("en", "ko", "all"), isNsfw = true, className = "MangaForFreeFactory", pkgName = "mangaforfree", overrideVersionCode = 1),
         MultiLang("Manhwa18.cc", "https://manhwa18.cc", listOf("en", "ko", "all"), isNsfw = true, className = "Manhwa18CcFactory", pkgName = "manhwa18cc", overrideVersionCode = 1),
-        MultiLang("Reaper Scans", "https://reaperscans.com", listOf("en", "pt-BR"), className = "ReaperScansFactory", pkgName = "reaperscans", overrideVersionCode = 3),
+        MultiLang("Reaper Scans", "https://reaperscans.com", listOf("en", "pt-BR"), className = "ReaperScansFactory", pkgName = "reaperscans", overrideVersionCode = 4),
         MultiLang("Seven King Scanlation", "https://sksubs.net", listOf("es", "en"), isNsfw = true),
         MultiLang("YugenMangas", "https://yugenmangas.com", listOf("es", "pt-BR"), overrideVersionCode = 2),
         SingleLang("1st Kiss Manga.love", "https://1stkissmanga.love", "en", className = "FirstKissMangaLove"),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

This PR aims to fix chapter names and dates in the ReaperScan En extension, which are currently broken and set to null.
