### PR TITLE
Fix: hentaifox.com second page issue

### DIFF
--- a/src/en/hentaifox/build.gradle
+++ b/src/en/hentaifox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'HentaiFox'
     pkgNameSuffix = 'en.hentaifox'
     extClass = '.HentaiFox'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/hentaifox/src/eu/kanade/tachiyomi/extension/en/hentaifox/HentaiFox.kt
+++ b/src/en/hentaifox/src/eu/kanade/tachiyomi/extension/en/hentaifox/HentaiFox.kt
@@ -31,7 +31,11 @@ class HentaiFox : ParsedHttpSource() {
     // Popular
 
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$baseUrl/pag/$page/", headers)
+        return if (page == 2) {
+            GET("$baseUrl/page/$page/", headers)
+        } else {
+            GET("$baseUrl/pag/$page/", headers)
+        }
     }
 
     override fun popularMangaSelector() = "div.thumb"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
