### PR TITLE
fix: manhwafull pagination

### DIFF
--- a/multisrc/overrides/madara/manhwafull/src/Manhwafull.kt
+++ b/multisrc/overrides/madara/manhwafull/src/Manhwafull.kt
@@ -1,0 +1,28 @@
+package eu.kanade.tachiyomi.extension.en.manhwafull
+
+import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.CacheControl
+import okhttp3.Request
+
+class Manhwafull : Madara("Manhwafull", "https://manhwafull.com", "en") {
+
+    override val useLoadMoreSearch = false
+
+    override fun popularMangaNextPageSelector(): String? = "a.nextpostslink"
+
+    override fun popularMangaRequest(page: Int): Request {
+        return GET(
+            "$baseUrl/manga-mwf/page/$page/?m_orderby=views",
+            formHeaders,
+            CacheControl.FORCE_NETWORK
+        )
+    }
+    override fun latestUpdatesRequest(page: Int): Request {
+        return GET(
+            "$baseUrl/manga-mwf/page/$page/?m_orderby=latest",
+            formHeaders,
+            CacheControl.FORCE_NETWORK
+        )
+    }
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -313,7 +313,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("ManhwaTime", "https://manhwatime.com", "ar"),
         SingleLang("ManhwaWorld", "https://manhwaworld.com", "en"),
         SingleLang("ManhwaXZ", "https://manhwaxz.com", "en"),
-        SingleLang("Manhwafull", "https://manhwafull.com", "en"),
+        SingleLang("Manhwafull", "https://manhwafull.com", "en", overrideVersionCode = 1),
         SingleLang("Manhwahentai.me", "https://manhwahentai.me", "en", className = "ManhwahentaiMe", isNsfw = true, overrideVersionCode = 2),
         SingleLang("Manhwaraw.net", "https://manhwaraw.net", "en", className = "Manhwarawnet"),
         SingleLang("Manhwatop", "https://manhwatop.com", "en", overrideVersionCode = 2),


### PR DESCRIPTION
Closes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/11602

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
