### PR TITLE
Komik Cast: fix another chapter image issue

### DIFF
--- a/multisrc/overrides/wpmangastream/komikcast/src/KomikCast.kt
+++ b/multisrc/overrides/wpmangastream/komikcast/src/KomikCast.kt
@@ -157,16 +157,7 @@ class KomikCast : WPMangaStream("Komik Cast", "https://komikcast.me", "id") {
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        val imageListRegex = Regex("chapterImages = (.*) \\|\\|")
-        val imageListJson = imageListRegex.find(document.toString())!!.destructured.toList()[0]
-        val imageList = json.parseToJsonElement(imageListJson).jsonObject
-
-        var imageServer = "cdn"
-        if (!imageList.containsKey(imageServer)) imageServer = imageList.keys.first()
-        val imageElement = imageList[imageServer]!!.jsonArray.joinToString("")
-        val doc = Jsoup.parse(json.decodeFromString(imageElement))
-
-        return doc.select("img.size-full")
+        return document.select("div#chapter_body .main-reading-area img")
             .mapIndexed { i, img -> Page(i, "", img.attr("abs:Src")) }
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpmangastream/WPMangaStreamGenerator.kt
@@ -22,7 +22,7 @@ class WPMangaStreamGenerator : ThemeSourceGenerator {
         SingleLang("Kanzenin", "https://kanzenin.xyz", "id", isNsfw = true),
         SingleLang("KlanKomik", "https://klankomik.com", "id", overrideVersionCode = 1),
         SingleLang("Komik AV", "https://komikav.com", "id", overrideVersionCode = 1),
-        SingleLang("Komik Cast", "https://komikcast.me", "id", overrideVersionCode = 11),
+        SingleLang("Komik Cast", "https://komikcast.me", "id", overrideVersionCode = 12),
         SingleLang("Komik Station", "https://komikstation.co", "id", overrideVersionCode = 3),
         SingleLang("KomikIndo.co", "https://komikindo.co", "id", className = "KomikindoCo", overrideVersionCode = 3),
         SingleLang("Kuma Scans (Kuma Translation)", "https://kumascans.com", "en", className = "KumaScans", overrideVersionCode = 1),


### PR DESCRIPTION
they change again how they load chapter image
closes #12162 
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
