### PR TITLE
Add www to irovedout URL

### DIFF
--- a/src/en/irovedout/build.gradle
+++ b/src/en/irovedout/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'I Roved Out'
     pkgNameSuffix = 'en.irovedout'
     extClass = '.IRovedOut'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/en/irovedout/src/eu/kanade/tachiyomi/extension/en/irovedout/IRovedOut.kt
+++ b/src/en/irovedout/src/eu/kanade/tachiyomi/extension/en/irovedout/IRovedOut.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 class IRovedOut : HttpSource() {
 
     override val name = "I Roved Out"
-    override val baseUrl = "https://irovedout.com"
+    override val baseUrl = "https://www.irovedout.com"
     override val lang = "en"
     override val supportsLatest = false
     private val archiveUrl = "$baseUrl/archive"


### PR DESCRIPTION
Fixes the extension not finding chapters.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
