### PR TITLE
LeviatanScans: Fix dates, description and status

### DIFF
--- a/multisrc/overrides/madara/leviatanscans/src/LeviatanScansFactory.kt
+++ b/multisrc/overrides/madara/leviatanscans/src/LeviatanScansFactory.kt
@@ -6,6 +6,8 @@ import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class LeviatanScansFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
@@ -13,7 +15,8 @@ class LeviatanScansFactory : SourceFactory {
         LeviatanScansES(),
     )
 }
-class LeviatanScansEN : Madara("Leviatan Scans", "https://leviatanscans.com", "en") {
+
+class LeviatanScansEN : Madara("Leviatan Scans", "https://leviatanscans.com", "en", SimpleDateFormat("MMM, yy", Locale.US)) {
     override val useNewChapterEndpoint: Boolean = true
 
     override fun popularMangaFromElement(element: Element) =
@@ -28,9 +31,10 @@ class LeviatanScansEN : Madara("Leviatan Scans", "https://leviatanscans.com", "e
     override fun chapterFromElement(element: Element) =
         replaceRandomUrlPartInChapter(super.chapterFromElement(element))
 
-    override val mangaDetailsSelectorDescription = "div.post-content div.manga-excerpt"
+    override val mangaDetailsSelectorStatus = ".post-content_item:contains(Status) .summary-content"
 }
-class LeviatanScansES : Madara("Leviatan Scans", "https://es.leviatanscans.com", "es") {
+
+class LeviatanScansES : Madara("Leviatan Scans", "https://es.leviatanscans.com", "es", SimpleDateFormat("MMM, yy", Locale("es"))) {
     override val useNewChapterEndpoint: Boolean = true
 
     override fun popularMangaFromElement(element: Element) =
@@ -44,6 +48,8 @@ class LeviatanScansES : Madara("Leviatan Scans", "https://es.leviatanscans.com",
 
     override fun chapterFromElement(element: Element) =
         replaceRandomUrlPartInChapter(super.chapterFromElement(element))
+
+    override val mangaDetailsSelectorStatus = ".post-content_item:contains(Status) .summary-content"
 }
 
 fun Madara.replaceRandomUrlPartInManga(manga: SManga): SManga {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -13,7 +13,7 @@ class MadaraGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 23
 
     override val sources = listOf(
-        MultiLang("Leviatan Scans", "https://leviatanscans.com", listOf("en", "es"), className = "LeviatanScansFactory", overrideVersionCode = 9),
+        MultiLang("Leviatan Scans", "https://leviatanscans.com", listOf("en", "es"), className = "LeviatanScansFactory", overrideVersionCode = 10),
         MultiLang("MangaForFree.net", "https://mangaforfree.net", listOf("en", "ko", "all"), isNsfw = true, className = "MangaForFreeFactory", pkgName = "mangaforfree", overrideVersionCode = 1),
         MultiLang("Manhwa18.cc", "https://manhwa18.cc", listOf("en", "ko", "all"), isNsfw = true, className = "Manhwa18CcFactory", pkgName = "manhwa18cc", overrideVersionCode = 2),
         MultiLang("Olympus Scanlation", "https://olympusscanlation.com", listOf("es", "pt-BR")),


### PR DESCRIPTION
Not sure about the date locale for `LeviatanScansES` since both US and ES locales work for now. I assumed it's ES since the hours/days ago are in spanish

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
