### PR TITLE
Komga: Improve status parsing

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.41
+
+Minimum Komga version required: `0.151.0`
+
+### Features
+
+* Improve how the status is displayed
+
 ## 1.3.40
 
 Minimum Komga version required: `0.151.0`

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 40
+    extVersionCode = 41
 }
 
 dependencies {

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.extension.all.komga.dto.PageDto
 import eu.kanade.tachiyomi.extension.all.komga.dto.PageWrapperDto
 import eu.kanade.tachiyomi.extension.all.komga.dto.ReadListDto
 import eu.kanade.tachiyomi.extension.all.komga.dto.SeriesDto
+import eu.kanade.tachiyomi.extension.all.komga.dto.SeriesMetadataDto
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -268,11 +269,7 @@ open class Komga(suffix: String = "") : ConfigurableSource, UnmeteredSource, Htt
             title = metadata.title
             url = "$baseUrl/api/v1/series/$id"
             thumbnail_url = "$url/thumbnail"
-            status = when (metadata.status) {
-                "ONGOING" -> SManga.ONGOING
-                "ENDED" -> SManga.COMPLETED
-                else -> SManga.UNKNOWN
-            }
+            status = parseStatus(metadata, booksCount)
             genre = (metadata.genres + metadata.tags + booksMetadata.tags).distinct().joinToString(", ")
             description = metadata.summary.ifBlank { booksMetadata.summary }
             booksMetadata.authors.groupBy { it.role }.let { map ->
@@ -317,6 +314,26 @@ open class Komga(suffix: String = "") : ConfigurableSource, UnmeteredSource, Htt
                 }
             }
         }
+
+    private fun parseStatus(metadata: SeriesMetadataDto, booksCount: Int): Int {
+        val tempStatus = when (metadata.status) {
+            "ONGOING" -> SManga.ONGOING
+            "ABANDONED" -> SManga.CANCELLED
+            "ENDED" -> SManga.PUBLISHING_FINISHED
+            "HIATUS" -> SManga.ON_HIATUS
+            else -> SManga.UNKNOWN
+        }
+
+        val publishedOrCancelled = tempStatus == SManga.PUBLISHING_FINISHED ||
+            tempStatus == SManga.CANCELLED
+        val totalBookCount = metadata.totalBookCount ?: booksCount
+
+        return if (booksCount >= totalBookCount && publishedOrCancelled) {
+            SManga.COMPLETED
+        } else {
+            tempStatus
+        }
+    }
 
     override fun imageUrlParse(response: Response): String = ""
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
@@ -42,7 +42,7 @@ data class SeriesMetadataDto(
     val genresLock: Boolean,
     val tags: Set<String>,
     val tagsLock: Boolean,
-    val totalBookCount: Int?
+    val totalBookCount: Int? = null
 )
 
 @Serializable

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
@@ -41,7 +41,8 @@ data class SeriesMetadataDto(
     val genres: Set<String>,
     val genresLock: Boolean,
     val tags: Set<String>,
-    val tagsLock: Boolean
+    val tagsLock: Boolean,
+    val totalBookCount: Int?
 )
 
 @Serializable


### PR DESCRIPTION
Closes #12644

How the status is parsed:
- `ENDED` + Total book count is missing/more than current book count: `Completed`
- `ENDED` + Total book count is less then the current book count: `Publication Finished`

Need a minimum of Komga v0.113.0 to work properly.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
