### PR TITLE
Leviatan Scans: Fix dates format

### DIFF
--- a/multisrc/overrides/madara/leviatanscans/src/LeviatanScansFactory.kt
+++ b/multisrc/overrides/madara/leviatanscans/src/LeviatanScansFactory.kt
@@ -16,7 +16,7 @@ class LeviatanScansFactory : SourceFactory {
     )
 }
 
-class LeviatanScansEN : Madara("Leviatan Scans", "https://leviatanscans.com", "en", SimpleDateFormat("MMM, yy", Locale.US)) {
+class LeviatanScansEN : Madara("Leviatan Scans", "https://leviatanscans.com", "en", SimpleDateFormat("MMM dd, yyyy", Locale.US)) {
     override val useNewChapterEndpoint: Boolean = true
 
     override fun popularMangaFromElement(element: Element) =

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -13,7 +13,7 @@ class MadaraGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 24
 
     override val sources = listOf(
-        MultiLang("Leviatan Scans", "https://leviatanscans.com", listOf("en", "es"), className = "LeviatanScansFactory", overrideVersionCode = 10),
+        MultiLang("Leviatan Scans", "https://leviatanscans.com", listOf("en", "es"), className = "LeviatanScansFactory", overrideVersionCode = 11),
         MultiLang("MangaForFree.net", "https://mangaforfree.net", listOf("en", "ko", "all"), isNsfw = true, className = "MangaForFreeFactory", pkgName = "mangaforfree", overrideVersionCode = 1),
         MultiLang("Manhwa18.cc", "https://manhwa18.cc", listOf("en", "ko", "all"), isNsfw = true, className = "Manhwa18CcFactory", pkgName = "manhwa18cc", overrideVersionCode = 2),
         MultiLang("Olympus Scanlation", "https://olympusscanlation.com", listOf("es", "pt-BR")),


### PR DESCRIPTION
The dates format changed again for the english website

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
