### PR TITLE
Fix a bug with mangasee intent filter

### DIFF
--- a/multisrc/overrides/nepnep/mangasee/AndroidManifest.xml
+++ b/multisrc/overrides/nepnep/mangasee/AndroidManifest.xml
@@ -16,7 +16,7 @@
  
                 <data
                     android:host="mangasee123.com"
-                    android:pathPattern="/manga/*"
+                    android:pathPattern="/manga/..*"
                     android:scheme="https" />
             </intent-filter>
         </activity>

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/nepnep/NepNepGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/nepnep/NepNepGenerator.kt
@@ -12,7 +12,7 @@ class NepNepGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 11
 
     override val sources = listOf(
-        SingleLang("MangaSee", "https://mangasee123.com", "en", overrideVersionCode = 21),
+        SingleLang("MangaSee", "https://mangasee123.com", "en", overrideVersionCode = 22),
         SingleLang("MangaLife", "https://manga4life.com", "en", overrideVersionCode = 16),
     )
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
