### PR TITLE
Update mangastic URL

### DIFF
--- a/multisrc/overrides/madara/mangastic/src/MangaStic.kt
+++ b/multisrc/overrides/madara/mangastic/src/MangaStic.kt
@@ -1,0 +1,6 @@
+package eu.kanade.tachiyomi.extension.en.ohnomanga
+import eu.kanade.tachiyomi.multisrc.madara.Madara
+
+class MangaStic : Madara("MangaStic", "https://mangastic.me", "en") {
+
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -284,7 +284,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("MangaSiro", "https://mangasiro.com", "en", isNsfw = true),
         SingleLang("MangaSmile", "https://mangasmile.com", "en", overrideVersionCode = 1),
         SingleLang("MangaSpark", "https://mangaspark.com", "ar", overrideVersionCode = 1),
-        SingleLang("MangaStic", "https://mangastic.com", "en"),
+        SingleLang("MangaStic", "https://mangastic.me", "en"),
         SingleLang("MangasTK", "https://mangastk.com", "es", isNsfw = true),
         SingleLang("Mangasushi", "https://mangasushi.org", "en", overrideVersionCode = 3),
         SingleLang("MangaTK", "https://mangatk.com", "en"),


### PR DESCRIPTION
Mangastic switched to mangastic.me recently, updating the URL

Closes issues: #12696 #11879 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
