### PR TITLE
Fix MangaDex.

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 167
+    extVersionCode = 168
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -57,7 +57,7 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
 
     final override fun headersBuilder() = Headers.Builder()
         .add("Referer", "$baseUrl/")
-        .add("User-Agent", "Tachiyomi " + System.getProperty("http.agent"))
+        .add("User-Agent", "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.79 Mobile Safari/537.36")
 
     override val client = network.client.newBuilder()
         .rateLimit(3)


### PR DESCRIPTION
MangaDex is currently blocking Tachiyomi. This changes the User-Agent to that of Chrome for Android to evade the block. Fixes #13431

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio