### PR TITLE
Comico: Replace CryptoJS with javax.crypto

### DIFF
--- a/src/all/comico/build.gradle
+++ b/src/all/comico/build.gradle
@@ -6,8 +6,12 @@ ext {
     extName = 'Comico'
     pkgNameSuffix = 'all.comico'
     extClass = '.ComicoFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(':lib-cryptoaes'))
+}

--- a/src/all/comico/src/eu/kanade/tachiyomi/extension/all/comico/Comico.kt
+++ b/src/all/comico/src/eu/kanade/tachiyomi/extension/all/comico/Comico.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.comico
 
 import android.webkit.CookieManager
-import app.cash.quickjs.QuickJs
+import eu.kanade.tachiyomi.lib.cryptoaes.CryptoAES
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -43,10 +43,6 @@ open class Comico(
     private val json by injectLazy<Json>()
 
     private val cookieManager by lazy { CookieManager.getInstance() }
-
-    private val cryptoJs by lazy {
-        client.newCall(GET(CRYPTOJS)).execute().body!!.string()
-    }
 
     private val imgHeaders by lazy {
         headersBuilder().set("Accept", ACCEPT_IMAGE).build()
@@ -166,14 +162,8 @@ open class Comico(
     private fun paginate(route: String, page: Int) =
         GET("$apiUrl/$route?pageNo=${page - 1}&pageSize=25", apiHeaders)
 
-    private fun String.decrypt() = QuickJs.create().use {
-        // javax.crypto.Cipher does not support empty IV
-        val script = """
-        const key = CryptoJS.enc.Utf8.parse('$AES_KEY'), iv = {words: []}
-        CryptoJS.AES.decrypt('$this', key, {iv}).toString(CryptoJS.enc.Utf8)
-        """
-        it.evaluate(cryptoJs + script).toString()
-    }
+    private fun String.decrypt() =
+        CryptoAES.decrypt(this, keyBytes, ivBytes)
 
     private val Response.data: JsonElement?
         get() = json.parseToJsonElement(body!!.string()).jsonObject.also {
@@ -206,8 +196,9 @@ open class Comico(
 
         private const val AES_KEY = "a7fc9dc89f2c873d79397f8a0028a4cd"
 
-        private const val CRYPTOJS =
-            "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/crypto-js.min.js"
+        private val keyBytes = AES_KEY.toByteArray(Charsets.UTF_8)
+
+        private val ivBytes = ByteArray(16) // Zero filled array as IV
 
         private const val ACCEPT_IMAGE =
             "image/avif,image/jxl,image/webp,image/*,*/*"


### PR DESCRIPTION
Replaced CryptoJS with javax.crypto. Also removed QuickJS Dependency.
Tested reading and downloads for various titles.

The `cryptoaes` lib has been modified, but the interface used by batoto and mangapark remains the same.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
