### PR TITLE
Comick.fun: fixed filter label misspelling

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Comick.fun'
     pkgNameSuffix = 'all.comickfun'
     extClass = '.ComickFunFactory'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFunFilters.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFunFilters.kt
@@ -10,7 +10,7 @@ internal fun getFilters(): FilterList {
         GenreFilter("Genre", getGenresList),
         DemographicFilter("Demographic", getDemographicList),
         TypeFilter("Type", getTypeList),
-        SortFilter("Short", getSortsList),
+        SortFilter("Sort", getSortsList),
         CreatedAtFilter("Created At", getCreatedAtList),
         MinimumFilter("Minimum Chapters"),
         Filter.Header("From Year, ex: 2010"),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
