### PR TITLE
Improve Reaper Scans metadata parsing

### DIFF
--- a/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
+++ b/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
@@ -111,6 +111,7 @@ class ReaperScansEn : ParsedHttpSource() {
             "On hold" -> SManga.ON_HIATUS
             "Complete" -> SManga.COMPLETED
             "Ongoing" -> SManga.ONGOING
+            "Dropped" -> SManga.CANCELLED
             else -> SManga.UNKNOWN
         }
 

--- a/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
+++ b/multisrc/overrides/madara/reaperscans/src/ReaperScansFactory.kt
@@ -113,6 +113,18 @@ class ReaperScansEn : ParsedHttpSource() {
             "Ongoing" -> SManga.ONGOING
             else -> SManga.UNKNOWN
         }
+
+        val genreList = mutableListOf<String>()
+        val seriesType = when (document.select("dt:contains(Source Language)").next().text()) {
+            "Korean" -> "Manhwa"
+            "Chinese" -> "Manhua"
+            "Japanese" -> "Manga"
+            else -> null
+        }
+
+        seriesType?.let { genreList.add(it) }
+
+        genre = genreList.takeIf { genreList.isNotEmpty() }?.joinToString(",")
         description = document.select("section > div:nth-child(1) > div > p").first().text()
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -17,7 +17,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         MultiLang("MangaForFree.net", "https://mangaforfree.net", listOf("en", "ko", "all"), isNsfw = true, className = "MangaForFreeFactory", pkgName = "mangaforfree", overrideVersionCode = 1),
         MultiLang("Manhwa18.cc", "https://manhwa18.cc", listOf("en", "ko", "all"), isNsfw = true, className = "Manhwa18CcFactory", pkgName = "manhwa18cc", overrideVersionCode = 2),
         MultiLang("Olympus Scanlation", "https://olympusscanlation.com", listOf("es", "pt-BR")),
-        MultiLang("Reaper Scans", "https://reaperscans.com", listOf("en", "fr", "id", "tr"), className = "ReaperScansFactory", pkgName = "reaperscans", overrideVersionCode = 8),
+        MultiLang("Reaper Scans", "https://reaperscans.com", listOf("en", "fr", "id", "tr"), className = "ReaperScansFactory", pkgName = "reaperscans", overrideVersionCode = 9),
         MultiLang("Seven King Scanlation", "https://sksubs.net", listOf("es", "en"), isNsfw = true),
         SingleLang("1st Kiss Manga.love", "https://1stkissmanga.love", "en", className = "FirstKissMangaLove", overrideVersionCode = 1),
         SingleLang("1st Kiss Manhua", "https://1stkissmanhua.com", "en", className = "FirstKissManhua", overrideVersionCode = 3),


### PR DESCRIPTION
This pull request adds support for parsing the following metadata to ReaperScans: 

 * Chapter Upload Date
 * Series Type
 * Cancellation Status 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio


**Note**: This pull request bumps the extension to the same version as #13781, assuming both PRs will be merged at the same time