### PR TITLE
fix: EarlyManga update baseUrl

### DIFF
--- a/src/en/earlymanga/build.gradle
+++ b/src/en/earlymanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'EarlyManga'
     pkgNameSuffix = 'en.earlymanga'
     extClass = '.EarlyManga'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/earlymanga/src/eu/kanade/tachiyomi/extension/en/earlymanga/EarlyManga.kt
+++ b/src/en/earlymanga/src/eu/kanade/tachiyomi/extension/en/earlymanga/EarlyManga.kt
@@ -28,7 +28,7 @@ class EarlyManga : ParsedHttpSource() {
 
     override val name = "EarlyManga"
 
-    override val baseUrl = "https://earlym.org"
+    override val baseUrl = "https://v1.earlym.org"
 
     override val lang = "en"
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Closes #13765 

Since the website now has a V2 version this PR just updates the source to their V1 website.

It may be important to rewrite the extension for the V2 website. I don't know if they will shut down the V1 in the future.