### PR TITLE
manga leveling chapter name fix

### DIFF
--- a/multisrc/overrides/madara/mangaleveling/src/MangaLeveling.kt
+++ b/multisrc/overrides/madara/mangaleveling/src/MangaLeveling.kt
@@ -1,7 +1,30 @@
 package eu.kanade.tachiyomi.extension.en.mangaleveling
 
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.source.model.SChapter
+import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class MangaLeveling : Madara("Manga Leveling", "https://mangaleveling.com", "en", SimpleDateFormat("MM/dd/yyyy", Locale.US))
+class MangaLeveling : Madara("Manga Leveling", "https://mangaleveling.com", "en", SimpleDateFormat("MM/dd/yyyy", Locale.US)) {
+
+    override fun chapterFromElement(element: Element): SChapter {
+        val chapter = SChapter.create()
+
+        with(element) {
+            select(chapterUrlSelector).first()?.let { urlElement ->
+                chapter.url = urlElement.attr("abs:href").let {
+                    it.substringBefore("?style=paged") + if (!it.endsWith(chapterUrlSuffix)) chapterUrlSuffix else ""
+                }
+                chapter.name = urlElement.selectFirst("span").text()
+            }
+            // Dates can be part of a "new" graphic or plain text
+            // Added "title" alternative
+            chapter.date_upload = select("img:not(.thumb)").firstOrNull()?.attr("alt")?.let { parseRelativeDate(it) }
+                ?: select("span a").firstOrNull()?.attr("title")?.let { parseRelativeDate(it) }
+                ?: parseChapterDate(select(chapterDateSelector()).firstOrNull()?.text())
+        }
+
+        return chapter
+    }
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -193,7 +193,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Manga Keyfi", "https://mangakeyfi.net", "tr"),
         SingleLang("Manga Kio", "https://mangakio.com", "en", isNsfw = true, overrideVersionCode = 1),
         SingleLang("Manga Kiss", "https://mangakiss.org", "en", overrideVersionCode = 1),
-        SingleLang("Manga Leveling", "https://mangaleveling.com", "en"),
+        SingleLang("Manga Leveling", "https://mangaleveling.com", "en", overrideVersionCode = 1),
         SingleLang("Manga Lord", "https://mangalord.com", "en", overrideVersionCode = 1),
         SingleLang("Manga Mitsu", "https://mangamitsu.com", "en", isNsfw = true, overrideVersionCode = 2),
         SingleLang("Manga One Love", "https://mangaonelove.site/", "ru", isNsfw = true),


### PR DESCRIPTION
Closes #13962 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
