### PR TITLE
Kavita: Bugfix/expected url scheme

### DIFF
--- a/src/all/kavita/CHANGELOG.md
+++ b/src/all/kavita/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.8
+
+### Fix
+
+* Fixed `Expected URL scheme 'http' or 'https` when downloading
+
 ## 1.3.7
 
 ### Features
@@ -6,6 +12,7 @@
 * New Filter: Year release filter
 
 ### Fix
+
 * Filters can now be used together with search
 * Epub and pdfs no longer show in format filter (currently not supported)
 

--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kavita'
     pkgNameSuffix = 'all.kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 dependencies {

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
@@ -491,9 +491,8 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
      * Fetches the "url" of each page from the chapter
      * **/
     override fun pageListRequest(chapter: SChapter): Request {
-        return GET("${chapter.url}/Reader/chapter-info")
+        return GET("$apiUrl/${chapter.url}", headersBuilder().build())
     }
-
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val chapterId = chapter.url
         val numPages = chapter.scanlator?.replace(" pages", "")?.toInt()
@@ -850,7 +849,10 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
     }
 
     override fun headersBuilder(): Headers.Builder {
-        if (jwtToken.isEmpty()) throw LoginErrorException("401 Error\nOPDS address got modified or is incorrect")
+        if (jwtToken.isEmpty()) {
+            doLogin()
+            if (jwtToken.isEmpty()) throw LoginErrorException("Error: jwt token is empty.\nTry opening the extension first")
+        }
         return Headers.Builder()
             .add("User-Agent", "Tachiyomi Kavita v${AppInfo.getVersionName()}")
             .add("Content-Type", "application/json")


### PR DESCRIPTION
This PR fixes an error when downloading that was apparently brought up in the latest preview version (r5254 and previous).

Latest preview version does now call `pageListRequest`  which from my understanding it shouldn't if `fetchPageList` is overriden.
I updated the method to return a dummy request to the chapter page since this call apparently does nothing in this use case.

I'm open to discussion if an issue should be raised in the main repo. Meanwhile here's valid fix for now (works with latest stable as well).

Note that this error only happens when downloading chapters.


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
