### PR TITLE
Update mangafreak base url to the latest working version

### DIFF
--- a/src/en/mangafreak/build.gradle
+++ b/src/en/mangafreak/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Mangafreak'
     pkgNameSuffix = 'en.mangafreak'
     extClass = '.Mangafreak'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 

--- a/src/en/mangafreak/src/eu/kanade/tachiyomi/extension/en/mangafreak/Mangafreak.kt
+++ b/src/en/mangafreak/src/eu/kanade/tachiyomi/extension/en/mangafreak/Mangafreak.kt
@@ -22,7 +22,7 @@ class Mangafreak : ParsedHttpSource() {
 
     override val lang: String = "en"
 
-    override val baseUrl: String = "https://w13.mangafreak.net"
+    override val baseUrl: String = "https://w14.mangafreak.net"
 
     override val supportsLatest: Boolean = true
 


### PR DESCRIPTION
Closes #14376.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
