### PR TITLE
Raw-manga: Fix chapter list not fetched

### DIFF
--- a/src/en/rawmanga/build.gradle
+++ b/src/en/rawmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Raw-Manga'
     pkgNameSuffix = 'en.rawmanga'
     extClass = '.RawManga'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/rawmanga/src/eu/kanade/tachiyomi/extension/en/rawmanga/RawManga.kt
+++ b/src/en/rawmanga/src/eu/kanade/tachiyomi/extension/en/rawmanga/RawManga.kt
@@ -88,7 +88,7 @@ class RawManga : ParsedHttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val mangaId = response.asJsoup().selectFirst(".btn-danger").attr("onclick")
-            .substringAfter("(").substringBefore(")")
+            .substringAfter("showAllCHaps(").substringBefore(")")
 
         val chapters = client.newCall(GET("$baseUrl/pieces/chaps.php?mng=$mangaId", headers)).execute()
 


### PR DESCRIPTION
Closes #14471
Closes #14431 

Incorrect manga id caused app not to fetch chapter list correctly. Affected delimiter has been updated.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
