### PR TITLE
Lib for custom and random user agents

### DIFF
--- a/lib/useragentmodifier/build.gradle.kts
+++ b/lib/useragentmodifier/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    compileSdk = AndroidConfig.compileSdk
+
+    defaultConfig {
+        minSdk = AndroidConfig.minSdk
+        targetSdk = AndroidConfig.targetSdk
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(libs.kotlin.stdlib)
+    compileOnly(libs.kotlin.json)
+    compileOnly(libs.okhttp)
+    compileOnly(libs.tachiyomi.lib)
+}

--- a/lib/useragentmodifier/src/main/AndroidManifest.xml
+++ b/lib/useragentmodifier/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.lib.useragentmodifier" />

--- a/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
+++ b/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
@@ -1,0 +1,59 @@
+package eu.kanade.tachiyomi.lib.useragentmodifier
+
+import android.content.SharedPreferences
+import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.source.ConfigurableSource
+
+interface UserAgentModifier : ConfigurableSource {
+    /**
+     * Override this property with the shared preferences of the source.
+     */
+    val preferences: SharedPreferences
+
+    /**
+     * The client should be used to obtain this property.
+     * Use: client.interceptors.toString().contains("UserAgentInterceptor")
+     */
+    val hasUaIntercept: Boolean
+
+    /**
+     * Override this property with the value null.
+     */
+    var userAgent: String?
+
+    /**
+     * Override this property with the value false.
+     */
+    var checkedUa: Boolean
+
+    /**
+     * Override this property with the value true to use a random user agent by default.
+     * This is a optional property that defaults false.
+     */
+    val useRandomUserAgentByDefault: Boolean
+        get() = false
+
+    /**
+     * Override with a list of Strings that must be present in the user agent.
+     * Example: listOf("chrome"), listOf("linux", "windows") and listOf("108")
+     * This is a optional property that defaults to an empty list.
+     */
+    val filterIncludeUserAgent: List<String>
+        get() = listOf()
+
+    /**
+     * Override with a list of Strings that should not be present in the user-agent.
+     * Example: listOf("chrome"), listOf("linux", "windows") and listOf("108")
+     * This is an optional property and defaults to an empty list.
+     */
+    val filterExcludeUserAgent: List<String>
+        get() = listOf()
+
+    /**
+     * This methods overrides ConfigurableSource interface to add preferences to set a custom and random user agent by default.
+     * AddRandomAndCustomUserAgentPreferences() should be called from inside the method when this one is overridden.
+     */
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        addRandomAndCustomUserAgentPreferences(screen)
+    }
+}

--- a/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
+++ b/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.lib.useragentmodifier
 import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.source.ConfigurableSource
+import okhttp3.OkHttpClient
 
 interface UserAgentModifier : ConfigurableSource {
     /**
@@ -11,10 +12,9 @@ interface UserAgentModifier : ConfigurableSource {
     val preferences: SharedPreferences
 
     /**
-     * The client should be used to obtain this property.
-     * Use: client.interceptors.toString().contains("UserAgentInterceptor")
+     * Override this property with the client of the source.
      */
-    val hasUaIntercept: Boolean
+    val client: OkHttpClient
 
     /**
      * Override this property with the value null.

--- a/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
+++ b/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifier.kt
@@ -50,7 +50,7 @@ interface UserAgentModifier : ConfigurableSource {
         get() = listOf()
 
     /**
-     * This methods overrides ConfigurableSource interface to add preferences to set a custom and random user agent by default.
+     * This methods overrides the ConfigurableSource interface to add the options to set a custom and random user agent.
      * AddRandomAndCustomUserAgentPreferences() should be called from inside the method when this one is overridden.
      */
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifierExtensions.kt
+++ b/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifierExtensions.kt
@@ -1,0 +1,143 @@
+package eu.kanade.tachiyomi.lib.useragentmodifier
+
+import android.util.Log
+import android.widget.Toast
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.PREF_KEY_CUSTOM_UA
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.PREF_KEY_RANDOM_UA
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.RESTART_APP_STRING
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.SUMMARY_CLEANING_CUSTOM_UA
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.TITLE_CUSTOM_UA
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.TITLE_RANDOM_UA
+import eu.kanade.tachiyomi.lib.useragentmodifier.UserAgentModifierConstants.UA_DB_URL
+import eu.kanade.tachiyomi.network.GET
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+fun UserAgentModifier.uaInterceptor(chain: Interceptor.Chain): Response {
+    val useRandomUa = preferences.getBoolean(PREF_KEY_RANDOM_UA, false)
+    val customUa = preferences.getString(PREF_KEY_CUSTOM_UA, "")
+
+    try {
+        if (hasUaIntercept && (useRandomUa || customUa!!.isNotBlank())) {
+            Log.i(
+                "Extension_setting",
+                "$TITLE_RANDOM_UA or $TITLE_CUSTOM_UA option is ENABLED",
+            )
+
+            if (customUa!!.isNotBlank() && useRandomUa.not()) {
+                userAgent = customUa
+            }
+
+            if (userAgent.isNullOrBlank() && !checkedUa) {
+                val uaResponse = chain.proceed(GET(UA_DB_URL))
+
+                if (uaResponse.isSuccessful) {
+                    var listUserAgentString =
+                        Json.decodeFromString<Map<String, List<String>>>(uaResponse.body.string())["desktop"]
+
+                    if (filterIncludeUserAgent.isNotEmpty()) {
+                        listUserAgentString = listUserAgentString!!.filter {
+                            filterIncludeUserAgent.any { filter ->
+                                it.contains(filter, ignoreCase = true)
+                            }
+                        }
+                    }
+                    if (filterExcludeUserAgent.isNotEmpty()) {
+                        listUserAgentString = listUserAgentString!!.filterNot {
+                            filterExcludeUserAgent.any { filter ->
+                                it.contains(filter, ignoreCase = true)
+                            }
+                        }
+                    }
+                    userAgent = listUserAgentString!!.random()
+                    checkedUa = true
+                }
+
+                uaResponse.close()
+            }
+
+            if (userAgent.isNullOrBlank().not()) {
+                val newRequest = chain.request().newBuilder()
+                    .header("User-Agent", userAgent!!.trim())
+                    .build()
+
+                return chain.proceed(newRequest)
+            }
+        }
+
+        return chain.proceed(chain.request())
+    } catch (e: Exception) {
+        throw IOException(e.message)
+    }
+}
+
+fun UserAgentModifier.addRandomAndCustomUserAgentPreferences(screen: PreferenceScreen) {
+    if (!hasUaIntercept) {
+        return // Unable to change the user agent. Therefore the preferences won't be displayed.
+    }
+
+    val prefRandomUserAgent = SwitchPreferenceCompat(screen.context).apply {
+        key = PREF_KEY_RANDOM_UA
+        title = TITLE_RANDOM_UA
+        summary = if (preferences.getBoolean(PREF_KEY_RANDOM_UA, useRandomUserAgentByDefault)) userAgent else ""
+        setDefaultValue(useRandomUserAgentByDefault)
+    }
+
+    val prefCustomUserAgent = EditTextPreference(screen.context).apply {
+        key = PREF_KEY_CUSTOM_UA
+        title = TITLE_CUSTOM_UA
+        summary = preferences.getString(PREF_KEY_CUSTOM_UA, "")!!.trim()
+    }
+
+    prefRandomUserAgent.setOnPreferenceChangeListener { _, newValue ->
+        val useRandomUa = newValue as Boolean
+        preferences.edit().putBoolean(PREF_KEY_RANDOM_UA, useRandomUa).apply()
+        if (!useRandomUa) {
+            Toast.makeText(screen.context, RESTART_APP_STRING, Toast.LENGTH_LONG).show()
+        } else {
+            userAgent = null
+            if (preferences.getString(PREF_KEY_CUSTOM_UA, "").isNullOrBlank().not()) {
+                Toast.makeText(screen.context, SUMMARY_CLEANING_CUSTOM_UA, Toast.LENGTH_LONG).show()
+            }
+        }
+
+        preferences.edit().putString(PREF_KEY_CUSTOM_UA, "").apply()
+        prefCustomUserAgent.summary = ""
+        true
+    }
+
+    prefCustomUserAgent.setOnPreferenceChangeListener { _, newValue ->
+        val customUa = newValue as String
+        preferences.edit().putString(PREF_KEY_CUSTOM_UA, customUa).apply()
+        if (customUa.isBlank()) {
+            Toast.makeText(screen.context, RESTART_APP_STRING, Toast.LENGTH_LONG).show()
+        } else {
+            userAgent = null
+        }
+        prefCustomUserAgent.summary = customUa.trim()
+        prefRandomUserAgent.summary = ""
+        prefRandomUserAgent.isChecked = false
+        true
+    }
+
+    screen.addPreference(prefRandomUserAgent)
+    screen.addPreference(prefCustomUserAgent)
+}
+
+object UserAgentModifierConstants {
+    const val TITLE_RANDOM_UA = "Use Random Latest User-Agent"
+    const val PREF_KEY_RANDOM_UA = "pref_key_random_ua"
+    const val TITLE_CUSTOM_UA = "Custom User-Agent"
+    const val PREF_KEY_CUSTOM_UA = "pref_key_custom_ua"
+    const val SUMMARY_CLEANING_CUSTOM_UA = "$TITLE_CUSTOM_UA cleared."
+    const val RESTART_APP_STRING = "Restart Tachiyomi to apply new setting."
+    const val UA_DB_URL = "https://tachiyomiorg.github.io/user-agents/user-agents.json"
+}
+
+

--- a/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifierExtensions.kt
+++ b/lib/useragentmodifier/src/main/java/eu/kanade/tachiyomi/lib/useragentmodifier/UserAgentModifierExtensions.kt
@@ -83,7 +83,7 @@ fun UserAgentModifier.addRandomAndCustomUserAgentPreferences(screen: PreferenceS
     if (!hasUaInterceptor()) {
         Log.i(
             "Extension_setting",
-            "The source implemented the UserAgentModifier, but the client lacks the UserAgentInterceptor"
+            "The source implemented the UserAgentModifier, but the client lacks the uaInterceptor"
         )
         return // Unable to modify the user agent. Therefore the preferences won't be displayed.
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 include(":core")
 
-listOf("dataimage", "unpacker", "cryptoaes", "textinterceptor").forEach {
+listOf("dataimage", "unpacker", "cryptoaes", "textinterceptor", "useragentmodifier").forEach {
     include(":lib-$it")
     project(":lib-$it").projectDir = File("lib/$it")
 }

--- a/src/en/reaperscans/build.gradle
+++ b/src/en/reaperscans/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Reaper Scans'
     pkgNameSuffix = 'en.reaperscans'
     extClass = '.ReaperScans'
-    extVersionCode = 42
+    extVersionCode = 43
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/reaperscans/build.gradle
+++ b/src/en/reaperscans/build.gradle
@@ -10,3 +10,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib-useragentmodifier"))
+}

--- a/src/en/reaperscans/src/eu/kanade/tachiyomi/extension/en/reaperscans/ReaperScans.kt
+++ b/src/en/reaperscans/src/eu/kanade/tachiyomi/extension/en/reaperscans/ReaperScans.kt
@@ -64,12 +64,8 @@ class ReaperScans : ParsedHttpSource(), UserAgentModifier {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
-    override val hasUaIntercept by lazy {
-        client.interceptors.toString().contains("UserAgentInterceptor")
-    }
-
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(::uaInterceptor)
+        .addInterceptor(uaInterceptor())
         .rateLimit(1, 2, TimeUnit.SECONDS)
         .build()
 


### PR DESCRIPTION
PR #15512 and #14688 add support for custom and random user agents for extensions. The problem is that if we apply this to other sources (#15539) it will lead to a lot of code duplication. I used Reaper Scans as an example.

Closes #15539
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
