### PR TITLE
MangaDex: When opening a chapter link, also display a series consisting of only that chapter

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangaDexFactory'
-    extVersionCode = 177
+    extVersionCode = 178
     isNsfw = true
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MDConstants.kt
@@ -125,6 +125,11 @@ object MDConstants {
         return "${tryUsingFirstVolumeCoverPref}_$dexLang"
     }
 
+    private const val chapterLinkSeriesPref = "chapterLinkSeries"
+    fun getChapterLinkSeriesPrefKey(dexLang: String): String {
+        return "${chapterLinkSeriesPref}_$dexLang"
+    }
+
     private const val tagGroupContent = "content"
     private const val tagGroupFormat = "format"
     private const val tagGroupGenre = "genre"

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt
@@ -235,6 +235,10 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
 
         val mangaObservable = seriesFromChapterData(chapterData, page, filters)
 
+        if (!preferences.chapterLinkSeries) {
+            return mangaObservable
+        }
+
         return mangaObservable.map { mangasPage ->
             val singleChapterManga = helper.createMangaFromSingleChapter(
                 chapterData,
@@ -822,10 +826,26 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
             }
         }
 
+        val chapterLinkSeriesPref = SwitchPreferenceCompat(screen.context).apply {
+            key = MDConstants.getChapterLinkSeriesPrefKey(dexLang)
+            title = helper.intl.chapterLinkSeries
+            summary = helper.intl.chapterLinkSeriesSummary
+            setDefaultValue(false)
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val checkValue = newValue as Boolean
+
+                preferences.edit()
+                    .putBoolean(MDConstants.getChapterLinkSeriesPrefKey(dexLang), checkValue)
+                    .commit()
+            }
+        }
+
         screen.addPreference(coverQualityPref)
         screen.addPreference(tryUsingFirstVolumeCoverPref)
         screen.addPreference(dataSaverPref)
         screen.addPreference(standardHttpsPortPref)
+        screen.addPreference(chapterLinkSeriesPref)
         screen.addPreference(contentRatingPref)
         screen.addPreference(originalLanguagePref)
         screen.addPreference(blockedGroupsPref)
@@ -897,6 +917,9 @@ abstract class MangaDex(final override val lang: String, private val dexLang: St
 
     private val SharedPreferences.useDataSaver
         get() = getBoolean(MDConstants.getDataSaverPreferenceKey(dexLang), false)
+
+    private val SharedPreferences.chapterLinkSeries
+        get() = getBoolean(MDConstants.getChapterLinkSeriesPrefKey(dexLang), false)
 
     /**
      * Previous versions of the extension allowed invalid UUID values to be stored in the

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -346,6 +346,35 @@ class MangaDexHelper(lang: String) {
     }
 
     /**
+     * Creates an [SManga] consisting of a single chapter.
+     * This is used when receiving chapter links via URL intent
+     */
+    fun createMangaFromSingleChapter(chapterDataDto: ChapterDataDto, seriesTitle: String? = null): SManga {
+        val chapter = createChapter(chapterDataDto)
+        return SManga.create().apply {
+            url = chapter.url
+            title = if (seriesTitle.isNullOrEmpty()) {
+                chapter.name
+            } else {
+                "${chapter.name} - $seriesTitle"
+            }
+            initialized = true
+            description = if (seriesTitle.isNullOrEmpty()) {
+                "Single chapter"
+            } else {
+                "Single chapter from series: $seriesTitle"
+            }
+            thumbnail_url = if (chapterDataDto.attributes?.chapter == null) {
+                "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Chapter&font_size=400&font=ariel"
+            } else if (chapterDataDto.attributes.volume.isNullOrEmpty()) {
+                "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Chapter%0A${chapterDataDto.attributes.chapter}&font_size=400&font=ariel"
+            } else {
+                "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Volume%0${chapterDataDto.attributes.volume}%0AChapter%0A${chapterDataDto.attributes.chapter}&font_size=300&font=ariel"
+            }
+        }
+    }
+
+    /**
      * Create the [SChapter] from the JSON element.
      */
     fun createChapter(chapterDataDto: ChapterDataDto): SChapter {

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexHelper.kt
@@ -369,7 +369,7 @@ class MangaDexHelper(lang: String) {
             } else if (chapterDataDto.attributes.volume.isNullOrEmpty()) {
                 "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Chapter%0A${chapterDataDto.attributes.chapter}&font_size=400&font=ariel"
             } else {
-                "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Volume%0${chapterDataDto.attributes.volume}%0AChapter%0A${chapterDataDto.attributes.chapter}&font_size=300&font=ariel"
+                "https://fakeimg.pl/1055x1500/111111/EEEEEE/?text=Volume%0A${chapterDataDto.attributes.volume}%0AChapter%0A${chapterDataDto.attributes.chapter}&font_size=300&font=ariel"
             }
         }
     }

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexIntl.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDexIntl.kt
@@ -87,6 +87,16 @@ class MangaDexIntl(lang: String) {
         else -> "Enables smaller, more compressed images"
     }
 
+    val chapterLinkSeries: String = when (availableLang) {
+        else -> "Show chapter links as series"
+    }
+
+    val chapterLinkSeriesSummary: String = when (availableLang) {
+        else ->
+            "When opening $MANGADEX_NAME chapter links in Tachiyomi, display an additional " +
+                "series in the search results that contains only that individual chapter"
+    }
+
     val standardHttpsPort: String = when (availableLang) {
         BRAZILIAN_PORTUGUESE, PORTUGUESE -> "Utilizar somente a porta 443 do HTTPS"
         SPANISH_LATAM, SPANISH -> "Utilizar el puerto 443 de HTTPS"


### PR DESCRIPTION
Currently, when opening a MangaDex chapter link in Tachiyomi, it just opens the series page. This is usually fine, however sometimes someone will post a link to a chapter without specifying which chapter it is, and if you have MangaDex set to open links in Tachiyomi by default, it can be annoying to try and figure out what chapter they were actually referring to.

This PR makes it so that when opening a chapter link in Tachiyomi, the app displays two different manga as search results. The first manga is the actual series that the chapter came from, as normal. The second manga contains only one chapter, which is the single chapter that the link was referring to.

I took inspiration from how the Dynasty Scans source has their "Dynasty Series" and "Dynasty Chapters" categories, and clicking a chapter link will display both the series and the chapter.

I've attached a demo to help clarify what I mean. I click on the link for Chapter 155 of the series, and two results come up: The actual manga that the chapter comes from, and another entry which contains only the relevant chapter.

https://user-images.githubusercontent.com/34069872/223622029-933044b7-9c74-4b6f-b557-665d6d914ba2.mp4

&nbsp;
If this PR is received positively, I intend to make something similar to open a specific single page of a manga.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] **(n/a)** Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] **(n/a)** Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] **(n/a)** Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] **(n/a)** Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
