### PR TITLE
MadTheme: Support fetching pages from lazy-loading hosts (like MangaB…

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madtheme/MadThemeGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madtheme/MadThemeGenerator.kt
@@ -9,7 +9,7 @@ class MadThemeGenerator : ThemeSourceGenerator {
 
     override val themeClass = "MadTheme"
 
-    override val baseVersionCode: Int = 11
+    override val baseVersionCode: Int = 12
 
     override val sources = listOf(
         SingleLang("BeeHentai", "https://beehentai.com", "en", isNsfw = true),


### PR DESCRIPTION
…uddy now)

Closes #15744

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
