### PR TITLE
Madokami: fix encoding special characters in url 

### DIFF
--- a/src/en/madokami/build.gradle
+++ b/src/en/madokami/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Madokami'
     pkgNameSuffix = 'en.madokami'
     extClass = '.Madokami'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -66,7 +66,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(element.attr("href"))
+        manga.url = element.attr("href")
         manga.title = URLDecoder.decode(element.attr("href").split("/").last(), "UTF-8").trimStart('!')
         return manga
     }


### PR DESCRIPTION
Fixes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/10447
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
