### PR TITLE
CI: check multisrc-related files

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Generate multisrc sources
         if: ${{ steps.parse-changed-files.outputs.isMultisrcChanged == '1' }}
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CHECK_MULTISRC_FILES: 1
         with:
@@ -116,7 +116,7 @@ jobs:
           distribution: adopt
 
       - name: Generate sources from the multi-source library
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MODULE_GEN: "true"
         with:
@@ -124,7 +124,7 @@ jobs:
           cache-read-only: true
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MULTISRC: "true"
           CI_CHUNK_NUM: ${{ matrix.chunk }}
@@ -150,7 +150,7 @@ jobs:
           distribution: adopt
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MULTISRC: "false"
           CI_CHUNK_NUM: ${{ matrix.chunk }}

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Generate multisrc sources
         if: ${{ steps.parse-changed-files.outputs.isMultisrcChanged == '1' }}
         uses: gradle/gradle-command-action@v2
+        env:
+          CHECK_MULTISRC_FILES: 1
         with:
           arguments: :multisrc:generateExtensions
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: adopt
 
       - name: Generate multisrc sources
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CHECK_MULTISRC_FILES: 1
         with:
@@ -91,14 +91,14 @@ jobs:
           echo ${{ secrets.SIGNING_KEY }} | base64 -d > signingkey.jks
 
       - name: Generate sources from the multi-source library
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MODULE_GEN: "true"
         with:
           arguments: :multisrc:generateExtensions
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MULTISRC: "true"
           CI_CHUNK_NUM: ${{ matrix.chunk }}
@@ -140,7 +140,7 @@ jobs:
           echo ${{ secrets.SIGNING_KEY }} | base64 -d > signingkey.jks
 
       - name: Build extensions (chunk ${{ matrix.chunk }})
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/gradle-build-action@v2
         env:
           CI_MULTISRC: "false"
           CI_CHUNK_NUM: ${{ matrix.chunk }}

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Generate multisrc sources
         uses: gradle/gradle-command-action@v2
+        env:
+          CHECK_MULTISRC_FILES: 1
         with:
           arguments: :multisrc:generateExtensions
 

--- a/multisrc/build.gradle.kts
+++ b/multisrc/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.io.BufferedReader
-import java.io.InputStreamReader
-
 plugins {
     id("com.android.library")
     kotlin("android")
@@ -59,16 +56,14 @@ tasks {
                 .directory(null).command(javaPath, "-classpath", classPath, mainClass)
                 .redirectErrorStream(true).start()
 
-            val inputStreamReader = InputStreamReader(javaProcess.inputStream)
-            val bufferedReader = BufferedReader(inputStreamReader)
-
-            var s: String?
-            while (bufferedReader.readLine().also { s = it } != null) {
-                logger.info(s)
+            javaProcess.inputStream.bufferedReader().use { reader ->
+                for (line in reader.lineSequence()) {
+                    when {
+                        line.startsWith("::") -> println(line)
+                        else -> logger.info(line)
+                    }
+                }
             }
-
-            bufferedReader.close()
-            inputStreamReader.close()
 
             val exitCode = javaProcess.waitFor()
             if (exitCode != 0) {

--- a/multisrc/build.gradle.kts
+++ b/multisrc/build.gradle.kts
@@ -36,10 +36,9 @@ tasks {
         classpath = configurations.compileOnly.get() +
             configurations.androidApis.get() + // android.jar path
             files("$buildDir/intermediates/aar_main_jar/debug/classes.jar") // jar made from this module
+        mainClass.set("generator.GeneratorMainKt")
 
         workingDir = workingDir.parentFile // project root
-
-        mainClass.set("generator.GeneratorMainKt")
 
         errorOutput = System.out // for GitHub workflow commands
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mccms/MCCMSGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mccms/MCCMSGenerator.kt
@@ -71,6 +71,7 @@ class MCCMSGenerator : ThemeSourceGenerator {
 
     override fun createAll() {
         val userDir = System.getProperty("user.dir")!!
+        checkRelatedFiles(userDir)
         sources.forEach {
             val themeClass = if (it.isNsfw) "MCCMSNsfw" else themeClass
             ThemeSourceGenerator.createGradleProject(it, themePkg, themeClass, baseVersionCode, userDir)

--- a/multisrc/src/main/java/generator/GeneratorMain.kt
+++ b/multisrc/src/main/java/generator/GeneratorMain.kt
@@ -25,4 +25,6 @@ fun main(args: Array<String>) {
                 }
                 .forEach { it.invoke(null, emptyArray<String>()) }
         }
+
+    ThemeSourceGenerator.checkOrphanedOverrides(userDir)
 }

--- a/multisrc/src/main/java/generator/GeneratorMain.kt
+++ b/multisrc/src/main/java/generator/GeneratorMain.kt
@@ -1,6 +1,7 @@
 package generator
 
 import java.io.File
+import kotlin.system.exitProcess
 
 /**
  * Finds and calls all `ThemeSourceGenerator`s
@@ -27,4 +28,7 @@ fun main(args: Array<String>) {
         }
 
     ThemeSourceGenerator.checkOrphanedOverrides(userDir)
+    if (ThemeSourceGenerator.isError && System.getenv("GITHUB_EVENT_NAME") == "pull_request") {
+        exitProcess(1)
+    }
 }

--- a/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
+++ b/multisrc/src/main/java/generator/ThemeSourceGenerator.kt
@@ -52,7 +52,7 @@ interface ThemeSourceGenerator {
                 file = generatorFile,
                 title = "Missing IntelliJ config",
                 message = "IntelliJ configuration file of '$generatorName' is missing. " +
-                    "Run `multisrc/src/main/java/generator/IntelijConfigurationGeneratorMain.kt` to generate it.",
+                    "Run 'multisrc/src/main/java/generator/IntelijConfigurationGeneratorMain.kt' to generate it.",
             )
         }
 


### PR DESCRIPTION
- When `CHECK_MULTISRC_FILES` environment variable is set, multisrc generator will check missing IntelliJ configs under `.run/` and orphaned overrides, annotate them on [run result](https://github.com/tachiyomiorg/tachiyomi-extensions/actions/runs/4636721079) and [changed files](https://web.archive.org/web/20230407083913/https://github.com/tachiyomiorg/tachiyomi-extensions/pull/15978/files), and exit with error.
  - Internally it's using `git ls-files` so it still works if you're working on a sparse checkout and don't have all the overrides locally. You only need to have all the generators.
- Rewrote the gradle task with `JavaExec`.
- ~~Cleaned up all the orphaned overrides present and fixed the config files.~~ (split into #15993)
