### PR TITLE
Madokami: Fix Manga details failed to load on deep subdirectory

### DIFF
--- a/src/en/madokami/build.gradle
+++ b/src/en/madokami/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Madokami'
     pkgNameSuffix = 'en.madokami'
     extClass = '.Madokami'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -66,7 +66,10 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
+        // manga.setUrlWithoutDomain(element.attr("href"))
         manga.url = element.attr("href")
+        var pathSegments = element.attr("href").split("/")
+
         manga.title = URLDecoder.decode(element.attr("href").split("/").last(), "UTF-8").trimStart('!')
         return manga
     }
@@ -86,10 +89,16 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
     override fun mangaDetailsRequest(manga: SManga): Request {
         val url = (baseUrl + manga.url).toHttpUrlOrNull()!!
         if (url.pathSize > 5 && url.pathSegments[0] == "Manga" && url.pathSegments[1].length == 1) {
-            return authenticate(GET(url.newBuilder().removePathSegment(5).build().toUrl().toExternalForm(), headers))
+            // return authenticate(GET(url.newBuilder().removePathSegment(5).build().toUrl().toExternalForm(), headers))
+            val builder = url.newBuilder()
+            for (i in 5 until url.pathSize) { builder.removePathSegment(5) }
+            return authenticate(GET(builder.build().toUrl().toExternalForm(), headers))
         }
         if (url.pathSize > 2 && url.pathSegments[0] == "Raws") {
-            return authenticate(GET(url.newBuilder().removePathSegment(2).build().toUrl().toExternalForm(), headers))
+            // return authenticate(GET(url.newBuilder().removePathSegment(2).build().toUrl().toExternalForm(), headers))
+            val builder = url.newBuilder()
+            for (i in 2 until url.pathSize) { builder.removePathSegment(2) }
+            return authenticate(GET(builder.build().toUrl().toExternalForm(), headers))
         }
         return authenticate(GET(url.toUrl().toExternalForm(), headers))
     }
@@ -108,6 +117,8 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         manga.thumbnail_url = document.select("div.manga-info img[itemprop=\"image\"]").attr("src")
         return manga
     }
+
+    override fun getMangaUrl(manga: SManga) = "$baseUrl/" + manga.url
 
     override fun chapterListRequest(manga: SManga) = authenticate(GET("$baseUrl/" + manga.url, headers))
 

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -116,7 +116,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         return manga
     }
 
-    override fun getMangaUrl(manga: SManga) = "$baseUrl" + manga.url
+    override fun getMangaUrl(manga: SManga) = "$baseUrl/" + manga.url.trimStart('/')
 
     override fun chapterListRequest(manga: SManga) = authenticate(GET("$baseUrl/" + manga.url, headers))
 

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -114,7 +114,7 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         return manga
     }
 
-    override fun getMangaUrl(manga: SManga) = "$baseUrl/" + manga.url
+    override fun getMangaUrl(manga: SManga) = "$baseUrl" + manga.url
 
     override fun chapterListRequest(manga: SManga) = authenticate(GET("$baseUrl/" + manga.url, headers))
 

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -68,8 +68,6 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         val manga = SManga.create()
         // manga.setUrlWithoutDomain(element.attr("href"))
         manga.url = element.attr("href")
-        var pathSegments = element.attr("href").split("/")
-
         manga.title = URLDecoder.decode(element.attr("href").split("/").last(), "UTF-8").trimStart('!')
         return manga
     }
@@ -89,13 +87,11 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
     override fun mangaDetailsRequest(manga: SManga): Request {
         val url = (baseUrl + manga.url).toHttpUrlOrNull()!!
         if (url.pathSize > 5 && url.pathSegments[0] == "Manga" && url.pathSegments[1].length == 1) {
-            // return authenticate(GET(url.newBuilder().removePathSegment(5).build().toUrl().toExternalForm(), headers))
             val builder = url.newBuilder()
             for (i in 5 until url.pathSize) { builder.removePathSegment(5) }
             return authenticate(GET(builder.build().toUrl().toExternalForm(), headers))
         }
         if (url.pathSize > 2 && url.pathSegments[0] == "Raws") {
-            // return authenticate(GET(url.newBuilder().removePathSegment(2).build().toUrl().toExternalForm(), headers))
             val builder = url.newBuilder()
             for (i in 2 until url.pathSize) { builder.removePathSegment(2) }
             return authenticate(GET(builder.build().toUrl().toExternalForm(), headers))

--- a/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
+++ b/src/en/madokami/src/eu/kanade/tachiyomi/extension/en/madokami/Madokami.kt
@@ -66,7 +66,6 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        // manga.setUrlWithoutDomain(element.attr("href"))
         manga.url = element.attr("href")
         manga.title = URLDecoder.decode(element.attr("href").split("/").last(), "UTF-8").trimStart('!')
         return manga
@@ -93,7 +92,10 @@ class Madokami : ConfigurableSource, ParsedHttpSource() {
         }
         if (url.pathSize > 2 && url.pathSegments[0] == "Raws") {
             val builder = url.newBuilder()
-            for (i in 2 until url.pathSize) { builder.removePathSegment(2) }
+            // to accomodate path pattern of /Raws/Magz/Series, this will remove all latter path segments that starts with !
+            // will fails if there's ever manga with ! prefix, but for now it works
+            var i = url.pathSize - 1
+            while (url.pathSegments[i].startsWith("!") && i >= 2) { builder.removePathSegment(i); i--; }
             return authenticate(GET(builder.build().toUrl().toExternalForm(), headers))
         }
         return authenticate(GET(url.toUrl().toExternalForm(), headers))


### PR DESCRIPTION
Fixes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/15988
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
