### PR TITLE
update MangaSwat URL

### DIFF
--- a/multisrc/overrides/mangathemesia/mangaswat/src/MangaSwat.kt
+++ b/multisrc/overrides/mangathemesia/mangaswat/src/MangaSwat.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 
 class MangaSwat : MangaThemesia(
     "MangaSwat",
-    "https://swatmanga.net",
+    "https://swatmanga.me",
     "ar",
     dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US),
 ) {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mangathemesia/MangaThemesiaGenerator.kt
@@ -68,7 +68,7 @@ class MangaThemesiaGenerator : ThemeSourceGenerator {
         SingleLang("MangaWT", "https://mangawt.com", "tr", overrideVersionCode = 5),
         SingleLang("Mangayaro", "https://mangayaro.net", "id"),
         SingleLang("Manhwa Lover", "https://manhwalover.com", "en", isNsfw = true, overrideVersionCode = 1),
-        SingleLang("MangaSwat", "https://swatmanga.net", "ar", overrideVersionCode = 6),
+        SingleLang("MangaSwat", "https://swatmanga.me", "ar", overrideVersionCode = 7),
         SingleLang("MangKomik", "https://mangkomik.net", "id", overrideVersionCode = 1),
         SingleLang("Mangás Chan", "https://mangaschan.com", "pt-BR", className = "MangasChan"),
         SingleLang("Manhwa Freak", "https://manhwafreak.com", "en", overrideVersionCode = 1),


### PR DESCRIPTION
Closes #16030

Looks to work fine after change.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
