### PR TITLE
[VizShonenJump] Add URL intent for series and chapter links

### DIFF
--- a/src/en/vizshonenjump/AndroidManifest.xml
+++ b/src/en/vizshonenjump/AndroidManifest.xml
@@ -1,2 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="eu.kanade.tachiyomi.extension" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.extension">
+
+    <application>
+        <activity
+            android:name=".en.vizshonenjump.VizUrlActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="www.viz.com" />
+                <data android:scheme="https" />
+
+                <data android:pathPattern="/..*/chapters/..*" />
+                <data android:pathPattern="/..*/..*/chapter/..*" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/en/vizshonenjump/build.gradle
+++ b/src/en/vizshonenjump/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'VIZ Shonen Jump'
     pkgNameSuffix = 'en.vizshonenjump'
     extClass = '.VizShonenJump'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 dependencies {

--- a/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizUrlActivity.kt
+++ b/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizUrlActivity.kt
@@ -1,0 +1,75 @@
+package eu.kanade.tachiyomi.extension.en.vizshonenjump
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+class VizUrlActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments: List<String>? = intent?.data?.pathSegments
+        if (!pathSegments.isNullOrEmpty() && pathSegments.size >= 3) {
+            // Have to use .equals, otherwise get an error 'Didn't find class "kotlin.jvm.internal.Intrinsics"'
+            val seriesSlug = if (pathSegments[2].equals("chapter") && contains(pathSegments[1], "-chapter-")) {
+                substringBeforeLast(pathSegments[1], "-chapter-")
+            } else {
+                pathSegments[2]
+            }
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra(
+                    "query",
+                    "${VizShonenJump.PREFIX_URL_SEARCH}/${pathSegments[0]}/chapters/$seriesSlug",
+                )
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("VizUrlActivity", "failed to start activity with error: $e")
+            }
+        } else {
+            Log.e("VizUrlActivity", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+
+    private fun containsAt(haystack: String, startIndex: Int, needle: String): Boolean {
+        for (i in 0 until needle.length) {
+            if (needle[i] != haystack[startIndex + i]) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun contains(haystack: String, needle: String): Boolean {
+        if (needle.length > haystack.length) {
+            return false
+        }
+        for (startIndex in 0..haystack.length - needle.length) {
+            if (containsAt(haystack, startIndex, needle)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun substringBeforeLast(haystack: String, needle: String): String {
+        if (needle.length > haystack.length) {
+            return haystack
+        }
+        for (startIndex in (haystack.length - needle.length) downTo 0) {
+            if (containsAt(haystack, startIndex, needle)) {
+                return haystack.subSequence(0, startIndex).toString()
+            }
+        }
+        return haystack
+    }
+}


### PR DESCRIPTION
Add URL intent to open series links (e.g. https://www.viz.com/shonenjump/chapters/kaiju-no-8) and chapter links (e.g. https://www.viz.com/shonenjump/kaiju-no-8-chapter-85/chapter/38004) in the extension.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] (n/a) Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] (n/a) Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] (n/a) Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] (n/a) Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
