### PR TITLE
Fix: page ordering & broken chapter loading

### DIFF
--- a/src/en/aurora/build.gradle
+++ b/src/en/aurora/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'aurora'
     pkgNameSuffix = 'en.aurora'
     extClass = '.Aurora'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
+++ b/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
@@ -145,7 +145,8 @@ class Aurora : HttpSource() {
 
         val chapterOverviewDoc = client.newCall(GET(chapterArchiveUrl, headers)).execute().asJsoup()
         val chapterBlockElements = chapterOverviewDoc.select(".wp-block-image")
-        val mangasFromChapters = chapterBlockElements
+        val mangasFromChapters: List<SManga> = chapterBlockElements
+            .filter { it -> it.selectFirst("a") != null }
             .mapIndexed { chapterIndex, chapter ->
                 val chapterOverviewLink = chapter.selectFirst("a")!!
                 val chapterOverviewUrl = chapterOverviewLink.attr("href")

--- a/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
+++ b/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
@@ -144,9 +144,8 @@ class Aurora : HttpSource() {
         val chapterArchiveUrl = "$baseUrl/archive/"
 
         val chapterOverviewDoc = client.newCall(GET(chapterArchiveUrl, headers)).execute().asJsoup()
-        val chapterBlockElements = chapterOverviewDoc.select(".wp-block-image")
+        val chapterBlockElements = chapterOverviewDoc.select(".wp-block-image:has(a)")
         val mangasFromChapters: List<SManga> = chapterBlockElements
-            .filter { it -> it.selectFirst("a") != null }
             .mapIndexed { chapterIndex, chapter ->
                 val chapterOverviewLink = chapter.selectFirst("a")!!
                 val chapterOverviewUrl = chapterOverviewLink.attr("href")

--- a/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
+++ b/src/en/aurora/src/eu/kanade/tachiyomi/extension/en/aurora/Aurora.kt
@@ -30,7 +30,7 @@ class Aurora : HttpSource() {
     override fun chapterListParse(response: Response): List<SChapter> = throw Exception("Not used")
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
-        return Observable.just(fetchChapterListTR(baseUrl + manga.url, mutableListOf()))
+        return Observable.just(fetchChapterListTR(baseUrl + manga.url, mutableListOf()).reversed())
     }
 
     private tailrec fun fetchChapterListTR(


### PR DESCRIPTION
An update to the comics page broke chapter loading, as the preview chapter did not have a link to use for the chapter overview.

I also saw that the ordering of the pages is wrong (which can manually be fixed by the end users, but that would have to be done for each new chapter).

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
