### PR TITLE
Fix BacaKomik no pages found

### DIFF
--- a/src/id/bacakomik/build.gradle
+++ b/src/id/bacakomik/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'BacaKomik'
     pkgNameSuffix = 'id.bacakomik'
     extClass = '.BacaKomik'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
+++ b/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
@@ -185,11 +185,14 @@ class BacaKomik : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         var i = 0
-        document.select("div.arkon-tachiyomi img").forEach { element ->
+        val cdnUrl = "https://ttl.bakul.buzz/" // change with correct CDN url
+        document.getElementsByTag("img").forEach { element ->
             val url = element.attr("onError").substringAfter("src='").substringBefore("';")
-            i++
-            if (url.isNotEmpty()) {
-                pages.add(Page(i, "", url))
+            if (url.startsWith(cdnUrl)) {
+                i++
+                if (url.isNotEmpty()) {
+                    pages.add(Page(i, "", url))
+                }
             }
         }
         return pages

--- a/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
+++ b/src/id/bacakomik/src/eu/kanade/tachiyomi/extension/id/bacakomik/BacaKomik.kt
@@ -185,7 +185,7 @@ class BacaKomik : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
         var i = 0
-        document.select("div.imgch-auh img").forEach { element ->
+        document.select("div.arkon-tachiyomi img").forEach { element ->
             val url = element.attr("onError").substringAfter("src='").substringBefore("';")
             i++
             if (url.isNotEmpty()) {


### PR DESCRIPTION
I aleready tested

Closes : #16949

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
