### PR TITLE
fix: uri must not be null on mmscans, switched to ajax loading, fix 4…

### DIFF
--- a/multisrc/overrides/madara/mmscans/src/MMScans.kt
+++ b/multisrc/overrides/madara/mmscans/src/MMScans.kt
@@ -49,7 +49,7 @@ class MMScans : Madara("MMScans", "https://mm-scans.org", "en") {
         return MangasPage(mangas, !hasNextPage)
     }
 
-    fun madara_load_more(page: Int, meta_key: String): Request {
+    fun oldLoadMoreRequest(page: Int, metaKey: String): Request {
         val form = FormBody.Builder()
             .add("action", "madara_load_more")
             .add("page", page.toString())

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -310,7 +310,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("MiniTwo Scan", "https://minitwoscan.com", "pt-BR"),
         SingleLang("Mirad Scanlator", "https://miradscanlator.site", "pt-BR", overrideVersionCode = 1),
         SingleLang("Mixed Manga", "https://mixedmanga.com", "en", overrideVersionCode = 1),
-        SingleLang("MMScans", "https://mm-scans.org", "en", overrideVersionCode = 5),
+        SingleLang("MMScans", "https://mm-scans.org", "en", overrideVersionCode = 6),
         SingleLang("Momo no Hana Scan", "https://momonohanascan.com", "pt-BR", className = "MomoNoHanaScan", overrideVersionCode = 1),
         SingleLang("MonarcaManga", "https://monarcamanga.com", "es"),
         SingleLang("MoonLovers Scan", "https://moonloversscan.com.br", "pt-BR", isNsfw = true),


### PR DESCRIPTION
…04 on the last page

Fixes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/16561

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
