### PR TITLE
latisbooks: fix page parsing, fix cover art

### DIFF
--- a/src/en/latisbooks/build.gradle
+++ b/src/en/latisbooks/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Latis Books'
     pkgNameSuffix = 'en.latisbooks'
     extClass = '.Latisbooks'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
+++ b/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
@@ -121,7 +121,7 @@ class Latisbooks : HttpSource() {
         val blocks = response.asJsoup().select("div.content-wrapper div.row div.col")
 
         // Handle multiple images per page (e.g. Page 23+24)
-        val pages = blocks.select("img.thumb-image")
+        val pages = blocks.select("div.image-block-wrapper img")
             .mapIndexed { i, it -> Page(i, "", it.attr("abs:data-src")) }
             .toMutableList()
 

--- a/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
+++ b/src/en/latisbooks/src/eu/kanade/tachiyomi/extension/en/latisbooks/Latisbooks.kt
@@ -37,7 +37,7 @@ class Latisbooks : HttpSource() {
             initialized = true
             title = "Bodysuit 23"
             url = "/archive/"
-            thumbnail_url = response.asJsoup().select("img.thumb-image").firstOrNull()?.attr("abs:data-src")
+            thumbnail_url = "https://images.squarespace-cdn.com/content/v1/56595108e4b01110e1cf8735/1511856223610-NSB8O5OJ1F6KPQL0ZGBH/image-asset.jpeg"
         }
     }
 


### PR DESCRIPTION
At some point recently (within the last week), latisbooks.com changed something about the site, likely a preprocessor update on their blog system. As a result, the extension was unable to find any pages. The first commit remedies this.

Additionally, I noticed that the cover art was completely broken, deciding not to load. As I use a custom art for my personal use, I'm not sure how long this has been a problem, but to remedy this I chose a cover piece from the comic to use as the unofficial official cover.

I want to note that this does not seem to be directly related to #16624, as the wording on that issue implies that the chapter list itself is not loadable. I had no issues with it loading during development, not during personal use for the past month and a half since that issue was raised.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
