### PR TITLE
Fix Japscan: Descrambling error

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 41
+    extVersionCode = 42
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -302,8 +302,8 @@ class Japscan : ConfigurableSource, ParsedHttpSource() {
         // Once we found the 8 strings, assuming they are always in the same order
         // Since Japscan reverse the char order, reverse the strings
         val stringLookupTables = listOf(
-            rawShortStringLookupTables[1].reversed() + rawLongStringLookupTables[5].reversed() + rawLongStringLookupTables[2].reversed() + rawLongStringLookupTables[0].reversed(),
-            rawShortStringLookupTables[2].reversed() + rawLongStringLookupTables[3].reversed() + rawLongStringLookupTables[4].reversed() + rawLongStringLookupTables[1].reversed(),
+            rawShortStringLookupTables[1].reversed() + rawLongStringLookupTables[1].reversed() + rawLongStringLookupTables[4].reversed() + rawLongStringLookupTables[0].reversed(),
+            rawShortStringLookupTables[2].reversed() + rawLongStringLookupTables[3].reversed() + rawLongStringLookupTables[5].reversed() + rawLongStringLookupTables[2].reversed(),
         )
 
         val scrambledData = document.getElementById("data")!!.attr("data-data")


### PR DESCRIPTION
The lookup tables have been updated on JapScan side

Closes #16957

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
