### PR TITLE
fix some manga id parse problem

### DIFF
--- a/multisrc/overrides/fmreader/kisslove/src/KissLove.kt
+++ b/multisrc/overrides/fmreader/kisslove/src/KissLove.kt
@@ -75,6 +75,6 @@ class KissLove : FMReader("KissLove", "https://klz9.com", "ja") {
     }
 
     companion object {
-        private val MID_URL_REGEX = "ybed-([^.]+).html".toRegex()
+        private val MID_URL_REGEX = "-([^.]+).html".toRegex()
     }
 }

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/fmreader/FMReaderGenerator.kt
@@ -15,7 +15,7 @@ class FMReaderGenerator : ThemeSourceGenerator {
     override val sources = listOf(
         MultiLang("Manhwa18.net", "https://manhwa18.net", listOf("en", "ko"), className = "Manhwa18NetFactory", isNsfw = true),
         SingleLang("Epik Manga", "https://www.epikmanga.com", "tr"),
-        SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 3),
+        SingleLang("KissLove", "https://klz9.com", "ja", isNsfw = true, overrideVersionCode = 4),
         SingleLang("Manga-TR", "https://manga-tr.com", "tr", className = "MangaTR", overrideVersionCode = 1),
         SingleLang("ManhuaRock", "https://manhuarock.net", "vi", overrideVersionCode = 1),
         SingleLang("Manhwa18", "https://manhwa18.com", "en", isNsfw = true, overrideVersionCode = 2),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
