### PR TITLE
Update OlympusScanlation domain

### DIFF
--- a/src/es/olympusscanlation/build.gradle
+++ b/src/es/olympusscanlation/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Olympus Scanlation'
     pkgNameSuffix = 'es.olympusscanlation'
     extClass = '.OlympusScanlation'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/olympusscanlation/src/eu/kanade/tachiyomi/extension/es/olympusscanlation/OlympusScanlation.kt
+++ b/src/es/olympusscanlation/src/eu/kanade/tachiyomi/extension/es/olympusscanlation/OlympusScanlation.kt
@@ -18,8 +18,8 @@ import java.util.Locale
 
 class OlympusScanlation : HttpSource() {
 
-    override val baseUrl: String = "https://olympusscans.com"
-    private val apiBaseUrl: String = "https://dashboard.olympusscans.com"
+    override val baseUrl: String = "https://olympusv2.gg"
+    private val apiBaseUrl: String = "https://dashboard.olympusv2.gg"
     override val lang: String = "es"
     override val name: String = "Olympus Scanlation"
     override val versionId = 2


### PR DESCRIPTION
Olympus Scan changed domain,
Closes https://github.com/tachiyomiorg/tachiyomi-extensions/issues/17431.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
