### PR TITLE
MangaFR: Fix chapterNames and mangaName while in manga details

### DIFF
--- a/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
+++ b/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
@@ -40,15 +40,16 @@ class MangaFR : MMRCMS("Manga-FR", "https://manga-fr.me", "fr") {
         // Parse date
         val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()
 
-        companion object {
-            val dateFormat by lazy {
-                SimpleDateFormat("d MMM. yyyy", Locale.US)
-            }
-        }
         chapter.date_upload = runCatching {
             dateFormat.parse(dateText)?.time
         }.getOrNull() ?: 0L
 
         return chapter
+    }
+
+    companion object {
+        val dateFormat by lazy {
+            SimpleDateFormat("d MMM. yyyy", Locale.US)
+        }
     }
 }

--- a/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
+++ b/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
@@ -39,8 +39,15 @@ class MangaFR : MMRCMS("Manga-FR", "https://manga-fr.me", "fr") {
 
         // Parse date
         val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()
-        val dateFormat = SimpleDateFormat("d MMM. yyyy", Locale.US)
-        chapter.date_upload = dateFormat.parse(dateText)?.time ?: 0L
+
+        companion object {
+            val dateFormat by lazy {
+                SimpleDateFormat("d MMM. yyyy", Locale.US)
+            }
+        }
+        chapter.date_upload = runCatching {
+            dateFormat.parse(dateText)?.time
+        }.getOrNull() ?: 0L
 
         return chapter
     }

--- a/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
+++ b/multisrc/overrides/mmrcms/mangafr/src/MangaFR.kt
@@ -1,0 +1,47 @@
+package eu.kanade.tachiyomi.extension.fr.mangafr
+
+import eu.kanade.tachiyomi.multisrc.mmrcms.MMRCMS
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import okhttp3.Response
+import org.jsoup.nodes.Element
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class MangaFR : MMRCMS("Manga-FR", "https://manga-fr.me", "fr") {
+    override fun mangaDetailsParse(response: Response): SManga {
+        return super.mangaDetailsParse(response).apply {
+            title = title.replace("Chapitres ", "")
+        }
+    }
+
+    override fun nullableChapterFromElement(element: Element): SChapter? {
+        val chapter = SChapter.create()
+
+        val titleWrapper = element.select("[class^=chapter-title-rtl]").first()!!
+        val chapterElement = titleWrapper.getElementsByTag("a")!!
+        val url = chapterElement.attr("href")
+
+        chapter.url = getUrlWithoutBaseUrl(url)
+
+        // Construct chapter names
+        // Before -> Scan <manga_name> <chapter_number> VF: <chapter_number>
+        // Now    -> Chapitre <chapter_number> : <chapter_title> OR Chapitre <chapter_number>
+        val chapterText = chapterElement.text()
+        val numberRegex = Regex("""[1-9]\d*(\.\d+)*""")
+        val chapterNumber = numberRegex.find(chapterText)?.value.orEmpty()
+        val chapterTitle = titleWrapper.getElementsByTag("em")!!.text()
+        if (chapterTitle.toIntOrNull() != null) {
+            chapter.name = "Chapitre $chapterNumber"
+        } else {
+            chapter.name = "Chapitre $chapterNumber : $chapterTitle"
+        }
+
+        // Parse date
+        val dateText = element.getElementsByClass("date-chapter-title-rtl").text().trim()
+        val dateFormat = SimpleDateFormat("d MMM. yyyy", Locale.US)
+        chapter.date_upload = dateFormat.parse(dateText)?.time ?: 0L
+
+        return chapter
+    }
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/mmrcms/MMRCMSGenerator.kt
@@ -25,7 +25,7 @@ class MMRCMSGenerator : ThemeSourceGenerator {
         SingleLang("AnimaRegia", "https://animaregia.net", "pt-BR", overrideVersionCode = 4),
         SingleLang("MangaID", "https://mangaid.click", "id", overrideVersionCode = 1),
         SingleLang("Jpmangas", "https://jpmangas.xyz", "fr", overrideVersionCode = 2),
-        SingleLang("Manga-FR", "https://manga-fr.me", "fr", className = "MangaFR"),
+        SingleLang("Manga-FR", "https://manga-fr.me", "fr", className = "MangaFR", overrideVersionCode = 1),
         SingleLang("Manga-Scan", "https://manga-scan.co", "fr", className = "MangaScan"),
         SingleLang("Ama Scans", "https://amascan.com", "pt-BR", isNsfw = true, overrideVersionCode = 2),
         // NOTE: THIS SOURCE CONTAINS A CUSTOM LANGUAGE SYSTEM (which will be ignored)!


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
