### PR TITLE
Comick: Fix beautify description

### DIFF
--- a/src/all/comickfun/build.gradle
+++ b/src/all/comickfun/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Comick'
     pkgNameSuffix = 'all.comickfun'
     extClass = '.ComickFunFactory'
-    extVersionCode = 34
+    extVersionCode = 35
     isNsfw = true
 }
 

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFun.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFun.kt
@@ -300,7 +300,7 @@ abstract class ComickFun(
                 timeZone = TimeZone.getTimeZone("UTC")
             }
         }
-        val markdownLinksRegex = "\\[([^]]+)\\]\\(([^)]+)\\)".toRegex()
+        val markdownLinksRegex = "\\[([^]]+)\\]\\(([^)]+)\\)(,|.)?".toRegex()
         val markdownItalicBoldRegex = "\\*+\\s*([^\\*]*)\\s*\\*+".toRegex()
         val markdownItalicRegex = "_+\\s*([^_]*)\\s*_+".toRegex()
     }

--- a/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFunHelper.kt
+++ b/src/all/comickfun/src/eu/kanade/tachiyomi/extension/all/comickfun/ComickFunHelper.kt
@@ -15,6 +15,7 @@ internal fun String.beautifyDescription(): String {
         .replace(markdownLinksRegex, "")
         .replace(markdownItalicBoldRegex, "")
         .replace(markdownItalicRegex, "")
+        .replace("\\", "")
         .trim()
 }
 


### PR DESCRIPTION
There are some comma/s and that was supposed to be removed along with markdown link (and backslash):
![image](https://github.com/tachiyomiorg/tachiyomi-extensions/assets/139281826/1832a391-b22a-41d4-83ae-50431de5b7c4)

![image](https://github.com/tachiyomiorg/tachiyomi-extensions/assets/139281826/e366f0a9-3074-4cb2-9413-4cba9ed1a99f)

&nbsp;

&nbsp;

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
