### PR TITLE
Update domain Nettruyen

### DIFF
--- a/multisrc/overrides/wpcomics/nettruyen/src/NetTruyen.kt
+++ b/multisrc/overrides/wpcomics/nettruyen/src/NetTruyen.kt
@@ -9,7 +9,7 @@ import okhttp3.Request
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class NetTruyen : WPComics("NetTruyen", "https://www.nettruyenmax.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
+class NetTruyen : WPComics("NetTruyen", "https://www.nettruyenus.com", "vi", SimpleDateFormat("dd/MM/yy", Locale.getDefault()), null) {
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
     override fun imageRequest(page: Page): Request = GET(page.imageUrl!!, headersBuilder().add("Referer", baseUrl).build())
     override fun getFilterList(): FilterList {

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpcomics/WPComicsGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/wpcomics/WPComicsGenerator.kt
@@ -12,7 +12,7 @@ class WPComicsGenerator : ThemeSourceGenerator {
     override val baseVersionCode: Int = 2
 
     override val sources = listOf(
-        SingleLang("NetTruyen", "https://www.nettruyenmax.com", "vi", overrideVersionCode = 18),
+        SingleLang("NetTruyen", "https://www.nettruyenus.com", "vi", overrideVersionCode = 19),
         SingleLang("NhatTruyen", "https://nhattruyenmin.com", "vi", overrideVersionCode = 11),
         SingleLang("TruyenChon", "http://truyenchon.com", "vi", overrideVersionCode = 3),
         SingleLang("XOXO Comics", "https://xoxocomics.net", "en", className = "XoxoComics", overrideVersionCode = 2),


### PR DESCRIPTION
Checklist:
Closes #17755 
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
