### PR TITLE
Fix: Manwa.me download and read only showing 3 pages

### DIFF
--- a/src/zh/manwa/build.gradle
+++ b/src/zh/manwa/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Manwa'
     pkgNameSuffix = 'zh.manwa'
     extClass = '.Manwa'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 


### PR DESCRIPTION
For #16752

- when only showing 3 pages, throw Exception, to make download task fail;
- Add a new preference, when only showing 3 pages, auto clear cookies;

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
