### PR TITLE
naver: fix author parsing and handle on hiatus status

### DIFF
--- a/src/ko/navercomic/build.gradle
+++ b/src/ko/navercomic/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Naver Comic'
     pkgNameSuffix = 'ko.navercomic'
     extClass = '.NaverComicFactory'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -108,8 +108,8 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
 
     override fun mangaDetailsParse(response: Response): SManga {
         val manga = json.decodeFromString<Manga>(response.body.string())
-        val authors = manga.author.run {
-            setOf(writers, painters, originAuthors).flatten().map { it.name }
+        val authors = manga.communityArtists.run {
+            this.map { it.name }
         }.joinToString()
 
         return SManga.create().apply {
@@ -215,7 +215,7 @@ data class Manga(
     val titleName: String,
     val titleId: Int,
     val finished: Boolean,
-    val author: AuthorList,
+    val communityArtists: List<Author>,
     val synopsis: String,
 )
 
@@ -229,14 +229,7 @@ data class MangaChallenge(
 )
 
 @Serializable
-data class AuthorList(
-    val writers: List<Author>,
-    val painters: List<Author>,
-    val originAuthors: List<Author>,
-)
-
-@Serializable
 data class Author(
-    val id: Int,
+    val artistId: Int,
     val name: String,
 )

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -108,9 +108,7 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
 
     override fun mangaDetailsParse(response: Response): SManga {
         val manga = json.decodeFromString<Manga>(response.body.string())
-        val authors = manga.communityArtists.run {
-            this.map { it.name }
-        }.joinToString()
+        val authors = manga.communityArtists.joinToString { it.name }
 
         return SManga.create().apply {
             title = manga.titleName

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -116,8 +116,8 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
             description = manga.synopsis
             thumbnail_url = manga.thumbnailUrl
             status = when {
-                manga.finished -> SManga.COMPLETED
                 manga.rest -> SManga.ON_HIATUS
+                manga.finished -> SManga.COMPLETED
                 else -> SManga.ONGOING
             }
         }

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -110,19 +110,16 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
         val manga = json.decodeFromString<Manga>(response.body.string())
         val authors = manga.communityArtists.joinToString { it.name }
 
-        var publishingStatus = SManga.ONGOING
-        if (manga.finished) {
-            publishingStatus = SManga.COMPLETED
-        } else if (manga.rest) {
-            publishingStatus = SManga.ON_HIATUS
-        }
-
         return SManga.create().apply {
             title = manga.titleName
             author = authors
             description = manga.synopsis
             thumbnail_url = manga.thumbnailUrl
-            status = publishingStatus
+            status = when {
+                manga.finished -> SManga.COMPLETED
+                manga.rest -> SManga.ON_HIATUS
+                else -> SManga.ONGOING
+            }
         }
     }
 

--- a/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
+++ b/src/ko/navercomic/src/eu/kanade/tachiyomi/extension/ko/navercomic/NaverComicBase.kt
@@ -110,12 +110,19 @@ abstract class NaverComicBase(protected val mType: String) : ParsedHttpSource() 
         val manga = json.decodeFromString<Manga>(response.body.string())
         val authors = manga.communityArtists.joinToString { it.name }
 
+        var publishingStatus = SManga.ONGOING
+        if (manga.finished) {
+            publishingStatus = SManga.COMPLETED
+        } else if (manga.rest) {
+            publishingStatus = SManga.ON_HIATUS
+        }
+
         return SManga.create().apply {
             title = manga.titleName
             author = authors
             description = manga.synopsis
             thumbnail_url = manga.thumbnailUrl
-            status = if (manga.finished) SManga.COMPLETED else SManga.ONGOING
+            status = publishingStatus
         }
     }
 
@@ -213,6 +220,7 @@ data class Manga(
     val titleName: String,
     val titleId: Int,
     val finished: Boolean,
+    val rest: Boolean,
     val communityArtists: List<Author>,
     val synopsis: String,
 )


### PR DESCRIPTION
Closes #17966
Closes #17948

naver's API changed how author info was stored in the response

additionally they added a secondary `rest` flag for series that are on hiatus. previously those series would have the `finished` flag set to true instead

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
