### PR TITLE
Fix Comic Fury extension search functionality

### DIFF
--- a/src/all/comicfury/build.gradle
+++ b/src/all/comicfury/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Comic Fury'
     pkgNameSuffix = 'all.comicfury'
     extClass = '.ComicFuryFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/comicfury/src/eu/kanade/tachiyomi/extension/all/comicfury/ComicFury.kt
+++ b/src/all/comicfury/src/eu/kanade/tachiyomi/extension/all/comicfury/ComicFury.kt
@@ -166,6 +166,7 @@ class ComicFury(
     }
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val req: HttpUrl.Builder = "$baseUrl/search.php".toHttpUrl().newBuilder()
+        req.addQueryParameter("query", query)
         req.addQueryParameter("page", page.toString())
         req.addQueryParameter("language", siteLang)
         filters.forEach {


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [X] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [X] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
