### PR TITLE
fix(EveriaClub): update searchMangaSelector

### DIFF
--- a/src/all/everiaclub/build.gradle
+++ b/src/all/everiaclub/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Everia.club'
     pkgNameSuffix = 'all.everiaclub'
     extClass = '.EveriaClub'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/all/everiaclub/src/eu/kanade/tachiyomi/extension/all/everiaclub/EveriaClub.kt
+++ b/src/all/everiaclub/src/eu/kanade/tachiyomi/extension/all/everiaclub/EveriaClub.kt
@@ -73,7 +73,7 @@ class EveriaClub() : ParsedHttpSource() {
         }
     }
 
-    override fun searchMangaSelector() = latestUpdatesSelector()
+    override fun searchMangaSelector() = "#content > article"
 
     // Details
     override fun mangaDetailsParse(document: Document): SManga {


### PR DESCRIPTION
Closes #18919

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
