### PR TITLE
999hentai tag search

### DIFF
--- a/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
+++ b/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
@@ -115,7 +115,7 @@ open class NineNineNineHentai(
                     format = filters.firstInstanceOrNull<FormatFilter>()?.selected,
                     tags = filters.firstInstanceOrNull<IncludedTagFilter>()?.selected,
                     excludeTags = filters.firstInstanceOrNull<ExcludedTagFilter>()?.tags,
-                    pagesRangeStart = filters.firstInstanceOrNull<MinPageFilter>()?.value,
+                    pagesRangeStart = if (filters.firstInstanceOrNull<MinPageFilter>()?.value == null && filters.firstInstanceOrNull<MaxPageFilter>()?.value != null) 1 else filters.firstInstanceOrNull<MinPageFilter>()?.value,
                     pagesRangeEnd = filters.firstInstanceOrNull<MaxPageFilter>()?.value,
                 ),
             ),

--- a/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
+++ b/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentai.kt
@@ -113,7 +113,7 @@ open class NineNineNineHentai(
                     language = siteLang,
                     sortBy = filters.firstInstanceOrNull<SortFilter>()?.selected,
                     format = filters.firstInstanceOrNull<FormatFilter>()?.selected,
-                    tags = filters.firstInstanceOrNull<IncludedTagFilter>()?.tags,
+                    tags = filters.firstInstanceOrNull<IncludedTagFilter>()?.selected,
                     excludeTags = filters.firstInstanceOrNull<ExcludedTagFilter>()?.tags,
                     pagesRangeStart = filters.firstInstanceOrNull<MinPageFilter>()?.value,
                     pagesRangeEnd = filters.firstInstanceOrNull<MaxPageFilter>()?.value,

--- a/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentaiFilters.kt
+++ b/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentaiFilters.kt
@@ -52,9 +52,15 @@ class MinPageFilter : PageFilter("Minimum Pages")
 
 class MaxPageFilter : PageFilter("Maximum Pages")
 
-class IncludedTagFilter : TagFilter("Include Tags")
-
+class IncludedTagFilter : SelectFilter(
+    "Include Tag",
+    genrePairs.distinct().sortedBy { it.first }.toTypedArray(),
+)
 class ExcludedTagFilter : TagFilter("Exclude Tags")
+
+private const val GENRE_TAGS = ",Uncensored,Futanari,Shotacon,Lolicon,Incest,Loli,Mind Control,Netorare,Milf,Rape,Bestiality,Yaoi,Yuri,Anal,Mother,Dark Skin,Tentacles,Sex Toys,Sole Female,Impregnation,Pregnant,Big Breasts,Gender Bender,Bondage,Femdom,Monster,Crossdressing,Harem,Lactation,Cheating,Ahegao,Huge Breasts,Tomgirl,Guro,Bbm,Feminization,Exhibitionism,Gyaru,Elf,Teacher,Masturbation,Stockings,Bdsm,Shota,Blackmail,Public Sex,Schoolgirl Uniform,Prostitution,Maid,Swimsuit,Blowjob,Group,Hairy,Paizuri,Torture,Vtuber"
+
+val genrePairs = GENRE_TAGS.split(",").map { it to it.lowercase() }.toTypedArray()
 
 fun getFilters() = FilterList(
     SortFilter(),
@@ -67,3 +73,5 @@ fun getFilters() = FilterList(
     ExcludedTagFilter(),
     Filter.Header("comma (,) separated tag/parody/character/artist/group"),
 )
+
+

--- a/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentaiPayloadDto.kt
+++ b/src/all/ninenineninehentai/src/eu/kanade/tachiyomi/extension/all/ninenineninehentai/NineNineNineHentaiPayloadDto.kt
@@ -29,7 +29,7 @@ data class SearchPayload(
     val language: String,
     val sortBy: String?,
     val format: String?,
-    val tags: List<String>?,
+    val tags: String?,
     val excludeTags: List<String>?,
     val pagesRangeStart: Int?,
     val pagesRangeEnd: Int?,


### PR DESCRIPTION
Closes: [#18885](https://github.com/tachiyomiorg/tachiyomi-extensions/issues/18885)

I changed the tag search to a ```Filter.Select``` type for the following reasons:

1. When a you search a genre by clicking on a tag, the function below eventually gets called in the main tachiyomi repository. The type ```Filter.Text``` won't get catched in this method and ends up just searching for the tag in the search bar. Also after skimming all sources, the only other source that has a genre tag filter of type ```Filter.Text``` is **nhentai**, which has a built-in tag searching algorithm in their website and therefore is appropriate.
```kotlin
//When a Tag gets clicked, performGenreSearch() in app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt 
//gets called, which calls searchGenre() in BrowseSourceScreen.kt in the same folder, which calls the method below

app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt 

fun searchGenre(genreName: String) {
        if (source !is CatalogueSource) return

        val defaultFilters = source.getFilterList()
        var genreExists = false

        filter@ for (sourceFilter in defaultFilters) {
            if (sourceFilter is SourceModelFilter.Group<*>) {
                for (filter in sourceFilter.state) {
                    if (filter is SourceModelFilter<*> && filter.name.equals(genreName, true)) {
                        when (filter) {
                            is SourceModelFilter.TriState -> filter.state = 1
                            is SourceModelFilter.CheckBox -> filter.state = true
                            else -> {}
                        }
                        genreExists = true
                        break@filter
                    }
                }
            } else if (sourceFilter is SourceModelFilter.Select<*>) {
                val index = sourceFilter.values.filterIsInstance<String>()
                    .indexOfFirst { it.equals(genreName, true) }

                if (index != -1) {
                    sourceFilter.state = index
                    genreExists = true
                    break
                }
            }
        }

        mutableState.update {
            val listing = if (genreExists) {
                Listing.Search(query = null, filters = defaultFilters)
            } else {
                Listing.Search(query = genreName, filters = defaultFilters)
            }
            it.copy(
                filters = defaultFilters,
                listing = listing,
                toolbarQuery = listing.query,
            )
        }
    }


```
2. The structure of the website **999hentai** allows multiple exclusion tags, but only one including tag. If you search multiple tags in the tachiyomi application, e.g. "uncensored, animated", the result is a union of single tag searches, which I don't think is an expected behavior for many users. (For this example, you will have a list of mangas containing either the tag "uncensored" or "animated") Therefore, instead of ```Filter.Group```, I implemented it with ```Filter.Select```.

Also fixed a bug that ignores the filter of min/max pages when only the max amount of pages is set.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
