### PR TITLE
Readcomiconline: Server preference added

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ReadComicOnline'
     pkgNameSuffix = 'en.readcomiconline'
     extClass = '.Readcomiconline'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 
 dependencies {

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -175,7 +175,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val qualitySuffix = if (qualitypref() != "lq" && serverpref() != "s2" || qualitypref() == "lq" && serverpref() == "s2") "&s=${serverpref()}&quality=${qualitypref()}" else "&s=${serverpref()}"
+        val qualitySuffix = if ((qualitypref() != "lq" && serverpref() != "s2") || (qualitypref() == "lq" && serverpref() == "s2")) "&s=${serverpref()}&quality=${qualitypref()}" else "&s=${serverpref()}"
         return GET(baseUrl + chapter.url + qualitySuffix, headers)
     }
 

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -175,7 +175,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val qualitySuffix = if (qualitypref() != "lq") "&quality=${qualitypref()}" else ""
+        val qualitySuffix = if (qualitypref() != "lq" && serverpref() != "s2" || qualitypref() == "lq" && serverpref() == "s2") "&s=${serverpref()}&quality=${qualitypref()}" else "&s=${serverpref()}"
         return GET(baseUrl + chapter.url + qualitySuffix, headers)
     }
 
@@ -280,9 +280,26 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
             }
         }
         screen.addPreference(qualitypref)
+        val serverpref = androidx.preference.ListPreference(screen.context).apply {
+            key = SERVER_PREF_TITLE
+            title = SERVER_PREF_TITLE
+            entries = arrayOf("Server 1", "Server 2")
+            entryValues = arrayOf("", "s2")
+            summary = "%s"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                val index = this.findIndexOfValue(selected)
+                val entry = entryValues[index] as String
+                preferences.edit().putString(SERVER_PREF, entry).commit()
+            }
+        }
+        screen.addPreference(serverpref)
     }
 
     private fun qualitypref() = preferences.getString(QUALITY_PREF, "hq")
+
+    private fun serverpref() = preferences.getString(SERVER_PREF, "")
 
     private var rguardUrl: String? = null
 
@@ -325,6 +342,8 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
     companion object {
         private const val QUALITY_PREF_Title = "Image Quality Selector"
         private const val QUALITY_PREF = "qualitypref"
+        private const val SERVER_PREF_TITLE = "Server Preference"
+        private const val SERVER_PREF = "serverpref"
 
         private val CHAPTER_IMAGES_REGEX = "lstImages\\.push\\([\"'](.*)[\"']\\)".toRegex()
         private val RGUARD_REGEX = Regex("""(function beau[\s\S]*\})""")


### PR DESCRIPTION
I made a list to choose from the 2 servers in the settings.

I checked this feature by opening chapters in Webview in the reader (not with the WebView button in the manga screen with the list of chapters) and observed that the server changes accordingly and should close [#18853](https://github.com/tachiyomiorg/tachiyomi-extensions/issues/18853)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

![Settings](https://github.com/tachiyomiorg/tachiyomi-extensions/assets/106656898/5e650b2e-c849-41b8-b7ff-42e482510bfb)
