### PR TITLE
Readcomiconline: Added new filters

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ReadComicOnline'
     pkgNameSuffix = 'en.readcomiconline'
     extClass = '.Readcomiconline'
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 dependencies {


### PR DESCRIPTION
Closes [#14581](https://github.com/tachiyomiorg/tachiyomi-extensions/issues/14581)
Additionally to the Publisher filter the issue wanted to have, I implemented Writer and Artist filter as well and the 4 sorting orders when one of the three is set.

I couldn't implement it sothat the new filters works with the tag and title search that was originally there, because when you want to search Publishers/Writers/Artists, you will have to go to this kind of an url: 
```https://readcomiconline.li/Publisher/DC-Comics/```,
which is varies from the original link: 
```https://readcomiconline.li/AdvanceSearch?comicName=&ig=&eg=41%2C&status=```

So the new filters is only activated the query and the genre tag filter is not set.
Also, when you set multiple of the new filters (e.g. Publisher = DC Comics, Artist = Adam DeKraker), the priority of the three filters looks like the following: **Publisher > Writer > Artist.** 
So in the example, Only Publisher = DC Comics is going to get applied.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
