### PR TITLE
Readcomiconline: fixed small issue to the new filter

### DIFF
--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ReadComicOnline'
     pkgNameSuffix = 'en.readcomiconline'
     extClass = '.Readcomiconline'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 dependencies {

--- a/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
+++ b/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt
@@ -132,6 +132,7 @@ class Readcomiconline : ConfigurableSource, ParsedHttpSource() {
                     }
                 }
                 addPathSegment((if (filters.isEmpty()) getFilterList() else filters).filterIsInstance<SortFilter>().first().selected.toString())
+                addQueryParameter("page", page.toString())
             }.build()
             return GET(url, headers)
         } else {


### PR DESCRIPTION
Fixed the issue of my previous [PR](https://github.com/tachiyomiorg/tachiyomi-extensions/pull/19262) that only the first page of the source is loaded, where it should load more.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
