### PR TITLE
[Kavita] Patch - Fix for null cast exception

### DIFF
--- a/src/all/kavita/CHANGELOG.md
+++ b/src/all/kavita/CHANGELOG.md
@@ -1,12 +1,19 @@
+## 1.3.13
+
+### Fixed
+
+ * Fixed 'null cannot be cast to non-null type' exception
+
 ## 1.3.12
 
-## Features
+### Features
 
 * Migrate filters to v2
 * Implemented smartFilters
 * Added localization support
 
-## Fixed
+### Fixed
+
 * Fixed publication status not showing
 
 ## 1.3.10

--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kavita'
     pkgNameSuffix = 'all.kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 dependencies {

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaInt.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaInt.kt
@@ -11,7 +11,7 @@ object KavitaInt {
         SPANISH,
         SPANISH_LATAM,
         NORWEGIAN,
-        FRENCH
+        FRENCH,
     )
     const val KAVITA_NAME = "Kavita"
 }


### PR DESCRIPTION
Fixed:
* Added missing null-check if smart-filter is not loaded (due to not being any in kavita instance)
* Added a more broad exception handler in fetch

An edge case that got past testing. Sorry for the inconvenience.
To be merged asap as it fixes search function.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
