### PR TITLE
Update Solar and Sundry API

### DIFF
--- a/src/en/solarandsundry/build.gradle
+++ b/src/en/solarandsundry/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Solar and Sundry'
     pkgNameSuffix = 'en.solarandsundry'
     extClass = '.SolarAndSundry'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/solarandsundry/build.gradle
+++ b/src/en/solarandsundry/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'Solar and Sundry'

--- a/src/en/solarandsundry/src/eu/kanade/tachiyomi/extension/en/solarandsundry/SolarAndSundry.kt
+++ b/src/en/solarandsundry/src/eu/kanade/tachiyomi/extension/en/solarandsundry/SolarAndSundry.kt
@@ -24,7 +24,7 @@ class SolarAndSundry : HttpSource() {
 
     override val name = "Solar and Sundry"
 
-    override val baseUrl = "https://solar-and-sundry-worker.giraugh.workers.dev"
+    override val baseUrl = "https://sas-api.fly.dev"
 
     override val lang = "en"
 
@@ -35,12 +35,12 @@ class SolarAndSundry : HttpSource() {
     private fun createManga(): SManga {
         return SManga.create().apply {
             title = "Solar and Sundry"
-            url = "/chapter"
+            url = "/page"
             author = "Ewan Breakey"
             artist = author
             status = SManga.ONGOING
-            description = "a sci-fi webcomic about creating an ecosystem where there shouldn't be one"
-            thumbnail_url = "https://imagedelivery.net/zthi1l8fKrUGB5ig08mq-Q/4b15df30-85c7-429e-d062-bf1d19f0fd00/public"
+            description = "a sci-fi horror webcomic about life blooming against all odds"
+            thumbnail_url = "https://imagedelivery.net/zthi1l8fKrUGB5ig08mq-Q/de292ba7-f164-4f43-ec17-1876a7a44600/public"
         }
     }
 
@@ -98,14 +98,7 @@ class SolarAndSundry : HttpSource() {
     // Chapters
 
     override fun chapterListParse(response: Response): List<SChapter> {
-        val chapters = JSONArray(response.body.string())
-        val pages = ArrayList<JSONObject>()
-        for (i in 0 until chapters.length()) {
-            val chapterPages = chapters.getJSONObject(i).getJSONArray("pages")
-            for (j in 0 until chapterPages.length()) {
-                pages.add(chapterPages.getJSONObject(j))
-            }
-        }
+        val pages = JSONArray(response.body.string())
         return pages.map { page ->
             SChapter.create().apply {
                 name = page.getString("name")


### PR DESCRIPTION
Updates the [Solar and Sundry](https://sas.ewanb.me/) extension to use the new version of the API, and also includes a new image and description.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
