### PR TITLE
Picacomic: Fix json decoding error of non-ASCII chars (#19434)

### DIFF
--- a/src/zh/picacomic/build.gradle
+++ b/src/zh/picacomic/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Picacomic'
     pkgNameSuffix = 'zh.picacomic'
     extClass = '.Picacomic'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
@@ -30,6 +30,7 @@ import org.json.JSONObject
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.net.URLEncoder
+import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -100,7 +101,7 @@ class Picacomic : HttpSource(), ConfigurableSource {
             )
         }
 
-        val payload = parts[1]?.let { JSONObject(Base64.decode(it, Base64.DEFAULT).decodeToString()) }
+        val payload = parts[1]?.let { JSONObject(Base64.decode(it, Base64.DEFAULT).toString(Charsets.UTF_8)) }
 
         val exp = payload?.getLong("exp")?.let {
             Date(it * 1000)

--- a/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
+++ b/src/zh/picacomic/src/eu/kanade/tachiyomi/extension/zh/picacomic/Picacomic.kt
@@ -100,7 +100,7 @@ class Picacomic : HttpSource(), ConfigurableSource {
             )
         }
 
-        val payload = parts[1]?.let { JSONObject(String(Base64.decode(it, Base64.DEFAULT))) }
+        val payload = parts[1]?.let { JSONObject(Base64.decode(it, Base64.DEFAULT).decodeToString()) }
 
         val exp = payload?.getLong("exp")?.let {
             Date(it * 1000)


### PR DESCRIPTION
Closes #19434
Caused by #19400

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio

I have no condition to test because the repo is too heavy, but it can work theoretically for its just a small change.
