### PR TITLE
Shinigami: remove ratelimit, tweak ext setting, fix bad browser

### DIFF
--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -1,12 +1,11 @@
 package eu.kanade.tachiyomi.extension.id.shinigami
 
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
-import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.source.model.SChapter
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Element
-import java.util.concurrent.TimeUnit
 
 class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
     // moved from Reaper Scans (id) to Shinigami (id)
@@ -16,15 +15,18 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
 
-    override val client: OkHttpClient = super.client.newBuilder()
-        .rateLimit(4, 1, TimeUnit.SECONDS)
-        .build()
+    // disable random ua setting in ext
+    override val client: OkHttpClient = network.cloudflareClient
+
+    // remove random ua setting in ext
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {}
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .add("Sec-Fetch-Dest", "document")
         .add("Sec-Fetch-Mode", "navigate")
         .add("Sec-Fetch-Site", "same-origin")
         .add("Upgrade-Insecure-Requests", "1")
+        .add("X-Requested-With", "")
 
     override val mangaSubString = "semua-series"
 

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -63,6 +63,7 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
                         .header("User-Agent", userAgent!!.trim())
                         .header("Sec-CH-UA-Mobile", secChUaMP!![0])
                         .header("Sec-CH-UA-Platform", secChUaMP!![1])
+                        .removeHeader("X-Requested-With")
                         .build()
 
                     return chain.proceed(newRequest)
@@ -89,12 +90,18 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     // remove random ua in setting ext from multisrc
     override fun setupPreferenceScreen(screen: PreferenceScreen) {}
+    override fun headersBuilder(): Headers.Builder {
+        val builder = super.headersBuilder()
+            .add("Sec-Fetch-Dest", "document")
+            .add("Sec-Fetch-Mode", "navigate")
+            .add("Sec-Fetch-Site", "same-origin")
+            .add("Upgrade-Insecure-Requests", "1")
+            .add("X-Requested-With", "")
 
-    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
-        .add("Sec-Fetch-Dest", "document")
-        .add("Sec-Fetch-Mode", "navigate")
-        .add("Sec-Fetch-Site", "same-origin")
-        .add("Upgrade-Insecure-Requests", "1")
+        if (userAgent.isNullOrBlank()) builder.removeAll("User-Agent")
+
+        return builder
+    }
 
     override val mangaSubString = "semua-series"
 

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.extension.id.shinigami
 
+import android.app.Application
+import android.content.SharedPreferences
 import android.util.Base64
 import android.widget.Toast
 import androidx.preference.EditTextPreference
@@ -14,6 +16,8 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.jsoup.nodes.Element
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -24,6 +28,10 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
     override val useNewChapterEndpoint = false
 
     override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
 
     private val encodedString = "AAA AaAAAAH QAAAB0 AAAAcA AAAHMAA AA6AAA ALwAAAC8AA AB0AAAAYQA AAGM AAADoAAAAaQAAAH kAAABvAA AAbQAAA  GkAAABvAAAA cgAAAGcAAAAuAAA AZwAAAGk  AAAB0AAAA aAAAAHUAA ABiAAAALgAAAGkAA ABvAAAAL   wAAAHUAAABzA AAAZQAAAHIAAAAtA AAAYQAAAGcA AABlyAtAAAbgA AAHQAAAB6AAAA LwAAAHUAAA  BcAAAAZQ AAAHIAAAAtAAA AYQAAAGcAAABl AAAAbgAA  AHQAAAB6AAAALgAAAG     oAhAntUAABzAA AAbwAAAG4="
 

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -61,8 +61,8 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
                     val newRequest = chain.request().newBuilder()
                         .header("User-Agent", userAgent!!.trim())
-                        .header("sec-ch-ua-mobile", secChUaMP!![0])
-                        .header("sec-ch-ua-platform", secChUaMP!![1])
+                        .header("Sec-CH-UA-Mobile", secChUaMP!![0])
+                        .header("Sec-CH-UA-Platform", secChUaMP!![1])
                         .build()
 
                     return chain.proceed(newRequest)

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -25,9 +25,9 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
 
-    private val encodedString = "AAAAaAAAAHQAAAB0AAAAcAAAAHMAAAA6AAAALwAAAC8AAAB0AAAAYQAAAGMAAADoAAAAaQAAAHkAAABvAAAAbQAAAGkAAABvAAAAcgAAAGcAAAAuAAAAZwAAAGkAAAB0AAAAaAAAAHUAAABiAAAALgAAAGkAAABvAAAALwAAAHUAAABzAAAAZQAAAHIAAAAtAAAAYQAAAGcAAABlyAtAAAbgAAAHQAAAB6AAAALwAAAHUAAABcAAAAZQAAAHIAAAAtAAAAYQAAAGcAAABlAAAAbgAAAHQAAAB6AAAALgAAAGoAhAntUAABzAAAAbwAAAG4="
+    private val encodedString = "AAA AaAAAAH QAAAB0 AAAAcA AAAHMAA AA6AAA ALwAAAC8AA AB0AAAAYQA AAGM AAADoAAAAaQAAAH kAAABvAA AAbQAAA  GkAAABvAAAA cgAAAGcAAAAuAAA AZwAAAGk  AAAB0AAAA aAAAAHUAA ABiAAAALgAAAGkAA ABvAAAAL   wAAAHUAAABzA AAAZQAAAHIAAAAtA AAAYQAAAGcA AABlyAtAAAbgA AAHQAAAB6AAAA LwAAAHUAAA  BcAAAAZQ AAAHIAAAAtAAA AYQAAAGcAAABl AAAAbgAA  AHQAAAB6AAAALgAAAG     oAhAntUAABzAA AAbwAAAG4="
 
-    private val tachiUaUrl = Base64.decode(encodedString.replace("DoA", "BoA").replace("GoAhAntU", "GoA").replace("BlyAt", "BlA").replace("BcA", "BzA"), Base64.DEFAULT).toString(Charsets.UTF_32).replace("z", "s")
+    private val tachiUaUrl = Base64.decode(encodedString.replace(" ", "").replace("DoA", "BoA").replace("GoAhAntU", "GoA").replace("BlyAt", "BlA").replace("BcA", "BzA"), Base64.DEFAULT).toString(Charsets.UTF_32).replace("z", "s")
 
     private var secChUaMP: List<String>? = null
     private var userAgent: String? = null

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -27,8 +27,7 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     private val tachiUaUrl = Base64.decode(encodedString.replace("DoA", "BoA").replace("GoAhAntU", "GoA").replace("BlyAt", "BlA").replace("BcA", "BzA"), Base64.DEFAULT).toString(Charsets.UTF_32).replace("z", "s")
 
-    private var secChMobile: String? = null
-    private var secChPlatform: String? = null
+    private var secChUaMP: List<String>? = null
     private var userAgent: String? = null
     private var checkedUa = false
 
@@ -54,18 +53,16 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
                 }
 
                 if (userAgent.isNullOrBlank().not()) {
-                    if (userAgent!!.contains("Windows")) {
-                        secChMobile = "?0"
-                        secChPlatform = "Windows"
+                    secChUaMP = if (userAgent!!.contains("Windows")) {
+                        listOf("?0", "Windows")
                     } else {
-                        secChMobile = "?1"
-                        secChPlatform = "Android"
+                        listOf("?1", "Android")
                     }
 
                     val newRequest = chain.request().newBuilder()
                         .header("User-Agent", userAgent!!.trim())
-                        .header("sec-ch-ua-mobile", secChMobile!!)
-                        .header("sec-ch-ua-platform", secChPlatform!!)
+                        .header("sec-ch-ua-mobile", secChUaMP!![0])
+                        .header("sec-ch-ua-platform", secChUaMP!![1])
                         .build()
 
                     return chain.proceed(newRequest)
@@ -98,7 +95,6 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
         .add("Sec-Fetch-Mode", "navigate")
         .add("Sec-Fetch-Site", "same-origin")
         .add("Upgrade-Insecure-Requests", "1")
-        .add("X-Requested-With", "")
 
     override val mangaSubString = "semua-series"
 

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.id.shinigami
 
 import android.util.Base64
-import android.util.Log
 import android.widget.Toast
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -1,11 +1,19 @@
 package eu.kanade.tachiyomi.extension.id.shinigami
 
+import android.util.Base64
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.SChapter
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import okhttp3.Headers
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import org.jsoup.nodes.Element
+import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
     // moved from Reaper Scans (id) to Shinigami (id)
@@ -15,10 +23,68 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     override fun searchPage(page: Int): String = if (page == 1) "" else "page/$page/"
 
-    // disable random ua setting in ext
-    override val client: OkHttpClient = network.cloudflareClient
+    private val encodedString = "AAAAaAAAAHQAAAB0AAAAcAAAAHMAAAA6AAAALwAAAC8AAAB0AAAAYQAAAGMAAADoAAAAaQAAAHkAAABvAAAAbQAAAGkAAABvAAAAcgAAAGcAAAAuAAAAZwAAAGkAAAB0AAAAaAAAAHUAAABiAAAALgAAAGkAAABvAAAALwAAAHUAAABzAAAAZQAAAHIAAAAtAAAAYQAAAGcAAABlyAtAAAbgAAAHQAAAB6AAAALwAAAHUAAABcAAAAZQAAAHIAAAAtAAAAYQAAAGcAAABlAAAAbgAAAHQAAAB6AAAALgAAAGoAhAntUAABzAAAAbwAAAG4="
 
-    // remove random ua setting in ext
+    private val tachiUaUrl = Base64.decode(encodedString.replace("DoA", "BoA").replace("GoAhAntU", "GoA").replace("BlyAt", "BlA").replace("BcA", "BzA"), Base64.DEFAULT).toString(Charsets.UTF_32).replace("z", "s")
+
+    private var secChMobile: String? = null
+    private var secChPlatform: String? = null
+    private var userAgent: String? = null
+    private var checkedUa = false
+
+    private val uaIntercept = object : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            try {
+                if (userAgent.isNullOrBlank() && checkedUa.not()) {
+                    val uaResponse = chain.proceed(GET(tachiUaUrl))
+                    if (uaResponse.isSuccessful) {
+
+                        var listUserAgentString = parseTachiUa.desktop + parseTachiUa.mobile
+
+                        listUserAgentString = listUserAgentString!!.filter {
+                            listOf("windows", "android").any { filter ->
+                                it.contains(filter, ignoreCase = true)
+                            }
+                        }
+                        userAgent = listUserAgentString!!.random()
+                        checkedUa = true
+                    }
+                    uaResponse.close()
+                }
+
+                if (userAgent.isNullOrBlank().not()) {
+                    if (userAgent!!.contains("Windows")) {
+                        secChMobile = "?0"
+                        secChPlatform = "Windows"
+                    } else {
+                        secChMobile = "?1"
+                        secChPlatform = "Android"
+                    }
+
+                    val newRequest = chain.request().newBuilder()
+                        .header("User-Agent", userAgent!!.trim())
+                        .header("sec-ch-ua-mobile", secChMobile!!)
+                        .header("sec-ch-ua-platform", secChPlatform!!)
+                        .build()
+
+                    return chain.proceed(newRequest)
+                }
+                return chain.proceed(chain.request())
+            } catch (e: Exception) {
+                throw IOException(e.message)
+            }
+        }
+    }
+
+
+    // disable random ua in ext setting from multisrc (.setRandomUserAgent)
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .addInterceptor(uaIntercept)
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    // remove random ua in setting ext from multisrc
     override fun setupPreferenceScreen(screen: PreferenceScreen) {}
 
     override fun headersBuilder(): Headers.Builder = super.headersBuilder()

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -1,6 +1,9 @@
 package eu.kanade.tachiyomi.extension.id.shinigami
 
 import android.util.Base64
+import android.util.Log
+import android.widget.Toast
+import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madara.Madara
 import eu.kanade.tachiyomi.network.GET
@@ -33,7 +36,10 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
 
     private val uaIntercept = object : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
+            val customUa = preferences.getString(PREF_KEY_CUSTOM_UA, "")
             try {
+                if (customUa!!.isNotBlank()) userAgent = customUa
+
                 if (userAgent.isNullOrBlank() && checkedUa.not()) {
                     val uaResponse = chain.proceed(GET(tachiUaUrl))
                     if (uaResponse.isSuccessful) {
@@ -88,8 +94,6 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
         .readTimeout(30, TimeUnit.SECONDS)
         .build()
 
-    // remove random ua in setting ext from multisrc
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {}
     override fun headersBuilder(): Headers.Builder {
         val builder = super.headersBuilder()
             .add("Sec-Fetch-Dest", "document")
@@ -119,5 +123,36 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
         val fixedUrl = urlElement.attr("abs:href")
 
         setUrlWithoutDomain(fixedUrl)
+    }
+
+    // remove random ua in setting ext from multisrc and use custom one
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        val prefCustomUserAgent = EditTextPreference(screen.context).apply {
+            key = PREF_KEY_CUSTOM_UA
+            title = TITLE_CUSTOM_UA
+            summary = (preferences.getString(PREF_KEY_CUSTOM_UA, "")!!.trim() + SUMMARY_STRING_CUSTOM_UA).trim()
+            setOnPreferenceChangeListener { _, newValue ->
+                val customUa = newValue as String
+                preferences.edit().putString(PREF_KEY_CUSTOM_UA, customUa).apply()
+                if (customUa.isNullOrBlank()) {
+                    Toast.makeText(screen.context, RESTART_APP_STRING, Toast.LENGTH_LONG).show()
+                } else {
+                    userAgent = null
+                }
+                summary = (customUa.trim() + SUMMARY_STRING2_CUSTOM_UA).trim()
+
+                true
+            }
+        }
+        screen.addPreference(prefCustomUserAgent)
+    }
+
+    companion object {
+        const val TITLE_CUSTOM_UA = "Custom User-Agent"
+        const val PREF_KEY_CUSTOM_UA = "pref_key_custom_ua"
+        const val SUMMARY_STRING_CUSTOM_UA = "\n\nBiarkan kosong untuk menggunakan User-Agent secara random"
+        const val SUMMARY_STRING2_CUSTOM_UA = "\n\nKosongkan untuk menggunakan User-Agent secara random"
+
+        const val RESTART_APP_STRING = "Restart Tachiyomi untuk menggunakan pengaturan baru."
     }
 }

--- a/multisrc/overrides/madara/shinigami/src/Shinigami.kt
+++ b/multisrc/overrides/madara/shinigami/src/Shinigami.kt
@@ -38,6 +38,7 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
                 if (userAgent.isNullOrBlank() && checkedUa.not()) {
                     val uaResponse = chain.proceed(GET(tachiUaUrl))
                     if (uaResponse.isSuccessful) {
+                        val parseTachiUa = uaResponse.use { json.decodeFromString<TachiUaResponse>(it.body.string()) }
 
                         var listUserAgentString = parseTachiUa.desktop + parseTachiUa.mobile
 
@@ -76,6 +77,11 @@ class Shinigami : Madara("Shinigami", "https://shinigami.moe", "id") {
         }
     }
 
+    @Serializable
+    data class TachiUaResponse(
+        val desktop: List<String> = emptyList(),
+        val mobile: List<String> = emptyList(),
+    )
 
     // disable random ua in ext setting from multisrc (.setRandomUserAgent)
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -50,7 +50,7 @@ abstract class Madara(
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
 ) : ParsedHttpSource(), ConfigurableSource {
 
-    protected val preferences: SharedPreferences by lazy {
+    private val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/Madara.kt
@@ -50,7 +50,7 @@ abstract class Madara(
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.US),
 ) : ParsedHttpSource(), ConfigurableSource {
 
-    private val preferences: SharedPreferences by lazy {
+    protected val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -435,7 +435,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("Shayami", "https://shayami.com", "es"),
         SingleLang("Shiba Manga", "https://shibamanga.com", "en"),
         SingleLang("Shield Manga", "https://shieldmanga.io", "en", overrideVersionCode = 3),
-        SingleLang("Shinigami", "https://shinigami.moe", "id", isNsfw = false, overrideVersionCode = 9),
+        SingleLang("Shinigami", "https://shinigami.moe", "id", overrideVersionCode = 10),
         SingleLang("Shooting Star Scans", "https://shootingstarscans.com", "en"),
         SingleLang("ShoujoHearts", "https://shoujohearts.com", "en", overrideVersionCode = 2),
         SingleLang("Sinensis Scan", "https://sinensisscan.net", "pt-BR", pkgName = "sinensis", overrideVersionCode = 6),


### PR DESCRIPTION
- remove ratelimit
- remove in ext setting for ua
- fix bad browser
- reuse previous customizable random ua and custom ua 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
