### PR TITLE
Update domain for Team X

### DIFF
--- a/src/ar/teamx/build.gradle
+++ b/src/ar/teamx/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Team X'
     pkgNameSuffix = 'ar.teamx'
     extClass = '.TeamX'
-    extVersionCode = 15
+    extVersionCode = 16
     isNsfw = false
 }
 

--- a/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
+++ b/src/ar/teamx/src/eu/kanade/tachiyomi/extension/ar/teamx/TeamX.kt
@@ -22,7 +22,7 @@ class TeamX : ParsedHttpSource() {
 
     override val name = "Team X"
 
-    override val baseUrl = "https://team11x11.com"
+    override val baseUrl = "https://team1x12.com"
 
     override val lang = "ar"
 


### PR DESCRIPTION
Closes #19565

Not sure where https://team1x1shojo.com/ comes from, but for me it redirects to https://team1x12.com/

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
